### PR TITLE
Allow multiple authors

### DIFF
--- a/app/components/article/template.njk
+++ b/app/components/article/template.njk
@@ -14,7 +14,7 @@
 {{- caller() if caller -}}
   </div>
 
-  {% if params.footer.date or params.footer.author %}
+  {% if params.footer.date or params.footer.author or params.footer.authors %}
   <footer class="app-article__footer">
     {% if params.footer.date %}
       Published <time datetime="{{ params.footer.date | date }}">{{ params.footer.date | date("d LLLL y") }}</time><br>
@@ -22,8 +22,16 @@
     {% if params.footer.modified %}
       Last updated <time datetime="{{ params.footer.modified | date }}">{{ params.footer.modified | date("d LLLL y") }}</time>
     {% endif %}
-    {% if params.footer.author %}
-      Written by {{ params.footer.author }}
+    {% if params.footer.author or params.footer.authors %}
+      Written by
+      {% if params.footer.author %}
+        {{ params.footer.author }}
+      {% else %}
+        {% set comma = joiner() %}
+        {% for author in params.footer.authors -%}
+          {{ comma() }} {{ author }}
+        {%- endfor %}
+      {% endif %}
     {% endif %}
   </footer>
   {% endif %}

--- a/app/layouts/post.njk
+++ b/app/layouts/post.njk
@@ -15,7 +15,8 @@
     footer: {
       date: date,
       modified: modified if modified,
-      author: author if author
+      author: author if author,
+      authors: authors if authors
     }
   }) %}
   <div class="govuk-grid-row">

--- a/docs/example-layouts/post.md
+++ b/docs/example-layouts/post.md
@@ -3,6 +3,7 @@ layout: post
 order: 2
 title: Post
 description: A date-based post
+author: Author name
 date: 2011-11-11
 related:
   items:


### PR DESCRIPTION
Useful for posts co-written by a few people.

Nunjucks doesn't seem to have a way to detect the type of a variable (eg array or string) so have suggested using `authors` in the frontmatter if there's multiple, and `author` if there's just one. Possibly that's more intuitive too?