### PR TITLE
Post author metadata

### DIFF
--- a/app/components/article/_article.scss
+++ b/app/components/article/_article.scss
@@ -69,10 +69,10 @@
 
 .app-article__footer {
   @include govuk-font($size: 16, $line-height: 1.5);
+  @include govuk-responsive-padding(4, "top");
   border-top: 1px solid $govuk-border-colour;
-  padding-top: govuk-spacing(2);
 
-  @include govuk-media-query($from: "tablet") {
-    max-width: 66%;
+  .govuk-body-s {
+    color: $govuk-secondary-text-colour;
   }
 }

--- a/app/components/article/template.njk
+++ b/app/components/article/template.njk
@@ -1,7 +1,17 @@
+{%- macro _authorLink(author) -%}
+  {%- if author.url -%}
+    <a class="govuk-link" href="{{ author.url }}">{{ author.name }}</a>
+  {%- else -%}
+    {{- author.name or author -}}
+  {%- endif -%}
+{% endmacro -%}
+
 <article class="app-article">
   {% if params.header %}
   <header class="app-article__header">
-    <h1 class="app-article__title govuk-heading-xl">{{ params.header.title }}</h1>
+    <h1 class="app-article__title govuk-heading-xl">
+      {{ params.header.title }}
+    </h1>
     {% if params.header.description %}
       <div class="govuk-body-l">
         {{ params.header.description }}
@@ -16,15 +26,24 @@
 
   {% if params.footer.date or params.footer.author %}
   <footer class="app-article__footer">
+    <p class="govuk-body-s">
+    {% if params.footer.authors %}
+      <span class="govuk-visually-hidden">Posted by: </span>
+      {%- for author in params.footer.authors -%}
+        {{- " and " if loop.last else (", " if not loop.first) -}}
+        {{- _authorLink(author) -}}
+      {%- endfor -%}
+    {% elif params.footer.author %}
+        {{- _authorLink(params.footer.author) -}}
+    {% endif %}
     {% if params.footer.date %}
-      Published <time datetime="{{ params.footer.date | date }}">{{ params.footer.date | date("d LLLL y") }}</time><br>
+      <span aria-hidden="true"> · </span><span class="govuk-visually-hidden">Posted on: </span><time datetime="{{ params.footer.date | date }}">{{ params.footer.date | date("d LLLL y") }}</time>
     {% endif %}
     {% if params.footer.modified %}
+      <span aria-hidden="true">•</span>
       Last updated <time datetime="{{ params.footer.modified | date }}">{{ params.footer.modified | date("d LLLL y") }}</time>
     {% endif %}
-    {% if params.footer.author %}
-      Written by {{ params.footer.author }}
-    {% endif %}
+    </p>
   </footer>
   {% endif %}
 </article>

--- a/app/layouts/post.njk
+++ b/app/layouts/post.njk
@@ -8,19 +8,21 @@
 {% endblock %}
 
 {% block content %}
-  {% call appArticle({
-    header: {
-      title: title
-    },
-    footer: {
-      date: date,
-      modified: modified if modified,
-      author: author if author
-    }
-  }) %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      {{ content }}
+      {% call appArticle({
+        header: {
+          title: title
+        },
+        footer: {
+          date: date,
+          modified: modified,
+          author: author,
+          authors: authors
+        }
+      }) %}
+        {{ content }}
+      {% endcall %}
     </div>
 
     {% if related.items | length > 0 %}
@@ -34,5 +36,4 @@
     </div>
     {% endif %}
   </div>
-  {% endcall %}
 {% endblock %}

--- a/docs/example-layouts/post.md
+++ b/docs/example-layouts/post.md
@@ -4,13 +4,19 @@ order: 2
 title: Post
 description: A date-based post
 date: 2011-11-11
+authors:
+  - name: William Ewart Gladstone
+    url: https://www.gov.uk/government/history/past-prime-ministers/william-ewart-gladstone
+  - name: Benjamin Disraeli
+    url: https://www.gov.uk/government/history/past-prime-ministers/benjamin-disraeli-the-earl-of-beaconsfield
 related:
   items:
-  - text: Another page
-    href: "#"
-  - text: Yet another page
-    href: "#"
+    - text: Another page
+      href: "#"
+    - text: Yet another page
+      href: "#"
 ---
+
 The `post` layout is designed for date-based content, such as blog posts or news items, with the optional to link to related content.
 
 ## Front matter properties
@@ -20,8 +26,15 @@ layout: post
 title: # Appears at the top of the page and in the <title>
 description: # Appears below page title and in page <meta>
 date: # Optional. See: https://www.11ty.dev/docs/dates/
+author: # Author name
+author:
+  - name: # Author name
+    url: # Author url
+authors:
+  - name: # Author name
+    url: # Author url
 related: # Optional. Related links appear in sidebar
   title: # Defaults to ‘Related links’
-  - text: # Title of related link
-    href: # URL for related link
+    - text: # Title of related link
+      href: # URL for related link
 ```

--- a/lib/markdown-it/deflist.js
+++ b/lib/markdown-it/deflist.js
@@ -4,8 +4,8 @@
  * @param {function} md markdown-it instance
  * @returns {function} markdown-it rendering rules
  */
- module.exports = function defList (md) {
+module.exports = function defList (md) {
   const { rules } = md.renderer
 
-  rules.dl_open = () => `<dl class="app-definition-list">\n`
+  rules.dl_open = () => '<dl class="app-definition-list">\n'
 }

--- a/lib/markdown-it/footnote.js
+++ b/lib/markdown-it/footnote.js
@@ -4,7 +4,7 @@
  * @param {function} md markdown-it instance
  * @returns {function} markdown-it rendering rules
  */
- module.exports = function footnotes (md) {
+module.exports = function footnotes (md) {
   const { rules } = md.renderer
 
   rules.footnote_ref = (tokens, idx, options, env, self) => {

--- a/lib/markdown-it/table-of-contents.js
+++ b/lib/markdown-it/table-of-contents.js
@@ -4,11 +4,11 @@
  * @param {function} md markdown-it instance
  * @returns {function} markdown-it rendering rules
  */
- module.exports = function contentsList (md) {
+module.exports = function contentsList (md) {
   const { rules } = md.renderer
 
   rules.toc_open = () => `<nav class="app-contents-list" aria-label="Contents" role="navigation">
     <h2 class="app-contents-list__title">Contents</h2>\n`
 
-  rules.toc_close = () => `</nav>`
+  rules.toc_close = () => '</nav>'
 }


### PR DESCRIPTION
More flexible options:

```yaml
author: Joe Bloggs
```

or

```yaml
author:
  name: Joe Bloggs
  url: https://example.org
```

or

```yaml
authors:
  - Joe Bloggs
  - Jane Doe
```

or

```yaml
authors:
  - name: Joe Bloggs
    url: https://example.org/~joe
```

or

```yaml
authors:
  - name: Joe Bloggs
    url: https://example.org/~joe
  - name: Jane Doe
    url: https://example.org/~jane
```

Example:

<img width="710" alt="Screenshot 2022-03-15 at 23 48 20" src="https://user-images.githubusercontent.com/813383/158490467-5eeb38cb-6aab-41e9-8069-278fe9f779cd.png">

Replaces #13.