### PR TITLE
Provide better control over Open Graph images

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -15,6 +15,7 @@ module.exports = function (eleventyConfig) {
       shortcut: 'https://raw.githubusercontent.com/x-govuk/logo/main/images/x-govuk-favicon.ico',
       touch: 'https://raw.githubusercontent.com/x-govuk/logo/main/images/x-govuk-apple-touch-icon.png'
     },
+    ogImage: 'https://raw.githubusercontent.com/x-govuk/logo/main/images/x-govuk-opengraph-image.png',
     homeKey: 'GOV.UK Eleventy Plugin',
     parentSite: {
       url: 'https://x-govuk.github.io/#shared-projects',

--- a/docs/layouts/collection.md
+++ b/docs/layouts/collection.md
@@ -27,6 +27,9 @@ includeInBreadcrumbs: # Show link to page in any breadcrumbs. Default is `false`
 order: # Adjust position of page in side navigation
 title: # Appears at the top of the page and in the <title>
 description: # Appears below page title and in page <meta>
+ogImage: # Open Graph image
+  src: # Image shown when sharing post
+  alt: # Alternative text for share image
 collection: # Name of collection. Default is ‘Posts’
 pagination: # Required. See https://www.11ty.dev/docs/pagination/
   data: # Required. Collection to show

--- a/docs/layouts/page.md
+++ b/docs/layouts/page.md
@@ -27,6 +27,9 @@ includeInBreadcrumbs: # Show link to page in any breadcrumbs. Default is `false`
 order: # Adjust position of page in side navigation
 title: # Appears at the top of the page and in the <title>
 description: # Appears below page title and in page <meta>
+ogImage: # Open Graph image
+  src: # Image shown when sharing post
+  alt: # Alternative text for share image
 related: # Related links (appears below content)
   sections:
     - title: # Default is ‘Related content’

--- a/docs/layouts/post.md
+++ b/docs/layouts/post.md
@@ -35,14 +35,18 @@ The `post` layout is designed for date-based content, such as blog posts or news
 ```yaml
 layout: post
 includeInBreadcrumbs: # Show link to page in any breadcrumbs. Default is `false`
-order: # Adjust position of page in side navigation
+order: # Number. Adjust position of page in side navigation
 title: # Appears at the top of the page and in the <title>
 description: # Appears below page title and in page <meta>
-date: # See https://www.11ty.dev/docs/dates/
+date: # Date. See https://www.11ty.dev/docs/dates/
 image:
-  src: # Image shown above the post and in Open Graph image
+  src: # Image shown above post content
   alt: # Alternative text for image
   caption: # Caption for image
+  ogImage: # Boolean. Whether to use image as share image as well
+ogImage: # Open Graph image. Overrides image (if image.ogImage is true)
+  src: # Image shown when sharing post
+  alt: # Alternative text for share image
 author: # Author name
 authors: # Author names (supersedes `author` value)
   - name: # Author name

--- a/docs/layouts/product.md
+++ b/docs/layouts/product.md
@@ -37,6 +37,10 @@ startButton: # Optional
 image:
   src: # Image source path for hero image.
   alt: # Textual alternative for hero image.
+  ogImage: # Boolean. Whether to use image as share image as well
+ogImage: # Open Graph image. Overrides image (if image.ogImage is true)
+  src: # Image shown when sharing post
+  alt: # Alternative text for share image
 related: # Related links (appears below content)
   sections:
     - title: # Default is ‘Related content’

--- a/docs/layouts/side-navigation.md
+++ b/docs/layouts/side-navigation.md
@@ -27,6 +27,9 @@ includeInBreadcrumbs: # Show link to page in any breadcrumbs. Default is `false`
 order: # Adjust position of page in side navigation
 title: # Appears at the top of the page and in the <title>
 description: # Appears below page title and in page <meta>
+ogImage: # Open Graph image
+  src: # Image shown when sharing post
+  alt: # Alternative text for share image
 related: # Related links (appears below content)
   sections:
     - title: # Default is ‘Related content’

--- a/docs/options.md
+++ b/docs/options.md
@@ -32,6 +32,7 @@ module.exports = function(eleventyConfig) {
 | **icons.mask** | string | Override the default GOV.UK SVG mask icon. | `false` |
 | **icons.shortcut** | string | Override the default GOV.UK favicon. | `false` |
 | **icons.touch** | string | Override the default GOV.UK touch icon. | `false` |
+| **ogImage** | string | Override the default GOV.UK Open Graph share image. | `false` |
 | **themeColour** | string | Browser theme colour. Must be a hex value. | `#0b0c0c` |
 | **homeKey** | string | Label to use for first item in pagination and key to use when referring to the home page for [`eleventyNavigation.parent`](https://www.11ty.dev/docs/plugins/navigation/). | `'Home'` |
 | **parentSite** | object | Website to show as first item in breadcrumbs. | `false` |

--- a/index.js
+++ b/index.js
@@ -49,6 +49,9 @@ module.exports = function (eleventyConfig, options = {}) {
   eleventyConfig.addPlugin(require('@11ty/eleventy-navigation'))
   eleventyConfig.addPlugin(require('@11ty/eleventy-plugin-rss'))
 
+  // Transforms
+  eleventyConfig.addTransform('replaceGovukOpenGraphImage', require('./lib/transforms/replace-govuk-open-graph-image.js')(options))
+
   // Events
   eleventyConfig.on('eleventy.after', async () => {
     require('./lib/events/generate-govuk-assets.js')(eleventyConfig, options)

--- a/layouts/base.njk
+++ b/layouts/base.njk
@@ -40,8 +40,9 @@
   <meta property="og:url" content="{{ config.url | url | absoluteUrl(config.url) }}">
   <meta property="og:title" content="{{ title }}">
   {% if description %}<meta property="og:description" name="description" content="{{ description | markdown("inline") | striptags(true) }}">{% endif %}
-  {% if image.src %}<meta property="og:image" content="{{ image.src | url | absoluteUrl(config.url) }}">{% endif %}
-  {% if image.alt %}<meta property="og:image:alt" content="{{ image.alt }}">{% endif %}
+  {% set ogImage = image if image.ogImage else igImage %}
+  {% if ogImage.src %}<meta property="og:image" content="{{ ogImage.src | url | absoluteUrl(config.url) }}">{% endif %}
+  {% if ogImage.alt %}<meta property="og:image:alt" content="{{ ogImage.alt }}">{% endif %}
 {% endblock %}
 
 {% block pageTitle %}

--- a/layouts/base.njk
+++ b/layouts/base.njk
@@ -1,5 +1,6 @@
 {% extends "govuk/template.njk" %}
 
+{% set assetUrl = assetPath | absoluteUrl(config.url) %}
 {% set htmlClasses = "no-js" %}
 {% set themeColor = config.themeColour %}
 

--- a/lib/transforms/replace-govuk-open-graph-image.js
+++ b/lib/transforms/replace-govuk-open-graph-image.js
@@ -1,0 +1,35 @@
+const url = require('@11ty/eleventy/src/Filters/Url.js')
+const absoluteUrl = require('@11ty/eleventy-plugin-rss/src/absoluteUrl.js')
+
+/**
+ * Replace stubbornly default GOV.UK Open Graph image with user defined image
+ *
+ * @param {object} options - Plugin options
+ * @returns {string}
+ */
+module.exports = (options) => {
+  return async (content, outputPath) => {
+    if (!options.ogImage) {
+      return
+    }
+
+    if (outputPath && outputPath.endsWith('.html')) {
+      // Open Graph image should respect any pathPrefix
+      let ogImageUrl = url(options.ogImage, options.pathPrefix)
+
+      // Open Graph image should have a canonical URL
+      ogImageUrl = absoluteUrl(ogImageUrl, options.url)
+
+      // Regex to find default GOV.UK Open Graph image in template.njk
+      const GOVUK_OGIMAGE_RE = /<meta property="og:image" content="(.*\/images\/govuk-opengraph-image\.png)">/g
+
+      const replacementUrl = (match, p1, offset, string) => {
+        return string.replace(p1, ogImageUrl)
+      }
+
+      content = content.replace(GOVUK_OGIMAGE_RE, replacementUrl)
+    }
+
+    return content
+  }
+}


### PR DESCRIPTION
Fixes #18.

## Add ability to set the default Open Graph image

The base template template provided by `govuk-frontend` includes the following HTML, which lies outside the realm of the `head` block:

```njk
{# The default og:image is added below head so that scrapers see any custom metatags first, and this is just a fallback #}
{# image url needs to be absolute e.g. http://wwww.domain.com/.../govuk-opengraph-image.png #}
<meta property="og:image" content="{{ assetUrl | default('/assets') }}/images/govuk-opengraph-image.png">
``` 

There are 2 means of overriding this default image, but both have shortcomings

1. Add a second `og:image` to the `head` block. The default however remains, and will sometimes appear when pages are shared (Apple products include all images in share previews, other services incorrectly display the last `og:image` in page source, rather than the first)
2. Set `assetUrl`. This only changes the URL, not the full path to the image. Pretty much useless.

See: https://github.com/alphagov/govuk-frontend/issues/1289

To get round this limitation, added a [transform](https://www.11ty.dev/docs/config/#transforms) function to rewrite pages after they have been generated. Yup, I’ve resorting to using a regex 😭.

Now, if authors provide `ogImage` in the plugin options, the default GOV.UK Open Graph image gets replaced. This URL can be the path to an image (which we’ll be correctly canonicalised with a sites `pathPrefix` and `url`, or a fully resolved URL.

## Add the ability to add an Open Graph image for a page

Pages can now set `ogImage.src` and `ogImage.alt`. For example:

```yaml
layout: page
title: About this site
ogImage:
  src: /assets/share-image.png
  alt: Alternative text for share image
```

This image appears in addition to the default, described above.

For layouts that accept an `image` param, they can set `image.ogImage: true`, saving the need to declare the image twice:

```yaml
layout: post
title: My great post
description: This post needs to be shared!
date: 2011-11-11
image:
  src: /assets/post-image.png
  alt: Alternative text for image
  caption: Caption for image
  ogImage: true
```

They can of course have a separate share image:

```yaml
layout: post
title: My great post
description: This post needs to be shared!
date: 2011-11-11
image:
  src: /assets/post-image.png
  alt: Alternative text for post image
  caption: Caption for post image
ogImage:
  src: /assets/share-image.png
  alt: Alternative text for share image
```