### PR TITLE
Display front matter options in a table. Fixes #21.

### DIFF
--- a/docs/includes/front-matter-options.md
+++ b/docs/includes/front-matter-options.md
@@ -1,0 +1,31 @@
+Use these options to customise the appearance, content and behaviour of any layout.
+
+| Name | Type | Description |
+| :--- | :--- | :---------- |
+| **layout** | string | Page layout. |
+| **includeInBreadcrumbs** | boolean | Include page as the last item in any breadcrumbs. Default is `false`. |
+| **order** | number | Ranking of page in navigation. Lower numbers appear before pages with a higher number. |
+| **title** | string | Page title. |
+| **description** | string | Page description. |
+| **ogImage** | object | Open Graph image that appears on social media networks. |
+| **ogImage.src** | string | Path to Open Graph image. Can be a relative or absolute URL. |
+| **ogImage.alt** | string | Alternative text for Open Graph image. |
+| **related** | object | Related links. See [related](#options-for-related). |
+
+### Options for related
+
+| Name | Type | Description |
+| :--- | :--- | :---------- |
+| **sections** | array | |
+| **sections.title** | string | Title for group of related links. Default is `'Related content'`. |
+| **sections.items** | array | See [items](#options-for-items). |
+| **sections.subsections** | array | Title for sub-group of related links. |
+| **sections.subsections.title** | string | |
+| **sections.subsections.items** | array | See [items](#options-for-items). |
+
+### Options for items
+
+| Name | Type | Description |
+| :--- | :--- | :---------- |
+| **text** | string | Title of related content. |
+| **href** | string | Link for the related content. |

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@ includeInBreadcrumbs: true
 description: Use this plugin for [Eleventy](https://www.11ty.dev) to spend time writing documentation, not building a website for it.
 image:
   src: /assets/homepage-illustration.png
-  alt: The Eleventy mascot floating above a laptop.
+  alt: Eleventy’s possum mascot hanging on a red balloon and floating above a laptop.
 startButton:
   href: /get-started
 eleventyComputed:

--- a/docs/layouts/collection.md
+++ b/docs/layouts/collection.md
@@ -2,7 +2,22 @@
 layout: collection
 order: 4
 title: Collection
-description: Layout for a collection of pages.
+description: Layout for a paginated list of pages.
+pagination:
+  data: example
+  size: 10
+collection: Example collection
+example:
+  - url: "#"
+    data:
+      date: 2021-08-17
+      title: Design changes after testing round three
+      description: Here are the changes we made after user research.
+  - url: "#"
+    data:
+      date: 2021-09-08
+      title: Helping users better find our service
+      description: Reviewing the user onboarding journey.
 related:
   sections:
     - title: Related links
@@ -17,34 +32,55 @@ related:
           - text: Front matter data
             href: https://www.11ty.dev/docs/data-frontmatter/
 ---
-The `collection` layout is designed for listing documents.
+Use front matter options to customise the appearance, content and behaviour of this layout.
 
-## Front matter properties
+For example, this page has the following options:
 
 ```yaml
 layout: collection
-includeInBreadcrumbs: # Show link to page in any breadcrumbs. Default is `false`
-order: # Adjust position of page in side navigation
-title: # Appears at the top of the page and in the <title>
-description: # Appears below page title and in page <meta>
-ogImage: # Open Graph image
-  src: # Image shown when sharing post
-  alt: # Alternative text for share image
-collection: # Name of collection. Default is ‘Posts’
-pagination: # Required. See https://www.11ty.dev/docs/pagination/
-  data: # Required. Collection to show
-  size: # Required. Number of items to show on each page
-related: # Related links (appears within sidebar)
+order: 4
+title: Collection
+description: Layout for a paginated list of pages.
+pagination:
+  data: example
+  size: 10
+collection: Example collection
+example:
+  - url: "#"
+    data:
+      date: 2021-08-17
+      title: Design changes after testing round three
+      description: Here are the changes we made after user research.
+  - url: "#"
+    data:
+      date: 2021-09-08
+      title: Helping users better find our service
+      description: Reviewing the user onboarding journey.
+related:
   sections:
-    - title: # Default is ‘Related content’
+    - title: Related links
       items:
-        - text: # Title of related link
-          href: # URL for related link
+        - text: Layouts
+          href: ../../layouts
+        - text: Options
+          href: ../../options
       subsections:
-        - title: # Title for subsection
+        - title: Eleventy documentation
           items:
-          - text: # Title of link in subsection
-            href: # URL for link in subsection
+          - text: Front matter data
+            href: https://www.11ty.dev/docs/data-frontmatter/
 ```
 
-View [the source for this page]({{ viewSource }}) on GitHub
+{% from "govuk/components/details/macro.njk" import govukDetails %}
+{% set detailsText %}{% include "../includes/front-matter-options.md" %}{% endset %}
+{{ govukDetails({
+  summaryText: "Common front matter options",
+  html: detailsText
+}) }}
+
+In addition to the common front matter options, this layout also accepts the following options:
+
+| Name | Type | Description |
+| :--- | :--- | :---------- |
+| **collection** | string | Title that appears above the list of documents. Default is `'Posts'`. |
+| **pagination** | object | Pages to show in the paginated list. Learn more about [pagination](https://www.11ty.dev/docs/pagination/) in the documentation for Eleventy. |

--- a/docs/layouts/page.md
+++ b/docs/layouts/page.md
@@ -2,7 +2,7 @@
 layout: page
 order: 1
 title: Page
-description: Layout for a simple page.
+description: Simple layout designed for maximum flexibility of content.
 related:
   sections:
     - title: Related links
@@ -17,30 +17,33 @@ related:
           - text: Front matter data
             href: https://www.11ty.dev/docs/data-frontmatter/
 ---
-The `page` layout is the simplest of layouts available. It is designed to allow maximum flexibility of the layout and type of page content.
+Use front matter options to customise the appearance, content and behaviour of this layout.
 
-## Front matter properties
+For example, this page has the following options:
 
 ```yaml
 layout: page
-includeInBreadcrumbs: # Show link to page in any breadcrumbs. Default is `false`
-order: # Adjust position of page in side navigation
-title: # Appears at the top of the page and in the <title>
-description: # Appears below page title and in page <meta>
-ogImage: # Open Graph image
-  src: # Image shown when sharing post
-  alt: # Alternative text for share image
-related: # Related links (appears below content)
+order: 1
+title: Page
+description: Simple layout designed for maximum flexibility of content.
+related:
   sections:
-    - title: # Default is ‘Related content’
+    - title: Related links
       items:
-        - text: # Title of related link
-          href: # URL for related link
+        - text: Layouts
+          href: ../../layouts
+        - text: Options
+          href: ../../options
       subsections:
-        - title: # Title for subsection
+        - title: Eleventy documentation
           items:
-          - text: # Title of link in subsection
-            href: # URL for link in subsection
+          - text: Front matter data
+            href: https://www.11ty.dev/docs/data-frontmatter/
 ```
 
-View [the source for this page]({{ viewSource }}) on GitHub
+{% from "govuk/components/details/macro.njk" import govukDetails %}
+{% set detailsText %}{% include "../includes/front-matter-options.md" %}{% endset %}
+{{ govukDetails({
+  summaryText: "Common front matter options",
+  html: detailsText
+}) }}

--- a/docs/layouts/post.md
+++ b/docs/layouts/post.md
@@ -2,7 +2,7 @@
 layout: post
 order: 3
 title: Post
-description: Layout for a date-based post.
+description: Layout for date-based content, such as blog posts or news items.
 date: 2011-11-11
 image:
   src: /assets/images/govuk-opengraph-image.png
@@ -27,43 +27,60 @@ related:
           - text: Front matter data
             href: https://www.11ty.dev/docs/data-frontmatter/
 ---
+Use front matter options to customise the appearance, content and behaviour of this layout.
 
-The `post` layout is designed for date-based content, such as blog posts or news items, with the optional to link to related content.
-
-## Front matter properties
+For example, this page has the following options:
 
 ```yaml
 layout: post
-includeInBreadcrumbs: # Show link to page in any breadcrumbs. Default is `false`
-order: # Number. Adjust position of page in side navigation
-title: # Appears at the top of the page and in the <title>
-description: # Appears below page title and in page <meta>
-date: # Date. See https://www.11ty.dev/docs/dates/
+order: 3
+title: Post
+description: Layout for date-based content, such as blog posts or news items.
+date: 2011-11-11
 image:
-  src: # Image shown above post content
-  alt: # Alternative text for image
-  caption: # Caption for image
-  ogImage: # Boolean. Whether to use image as share image as well
-ogImage: # Open Graph image. Overrides image (if image.ogImage is true)
-  src: # Image shown when sharing post
-  alt: # Alternative text for share image
-author: # Author name
-authors: # Author names (supersedes `author` value)
-  - name: # Author name
-    url: # Author url
-  - name: # Author name
-    url: # Author url
-related: # Related links (appears within sidebar)
+  src: /assets/images/govuk-opengraph-image.png
+  alt: A crown icon above the words GOV.UK.
+  caption: The GOV.UK logo
+authors:
+  - name: William Ewart Gladstone
+    url: https://www.gov.uk/government/history/past-prime-ministers/william-ewart-gladstone
+  - name: Benjamin Disraeli
+    url: https://www.gov.uk/government/history/past-prime-ministers/benjamin-disraeli-the-earl-of-beaconsfield
+related:
   sections:
-    - title: # Default is ‘Related content’
+    - title: Related links
       items:
-        - text: # Title of related link
-          href: # URL for related link
+        - text: Layouts
+          href: ../../layouts
+        - text: Options
+          href: ../../options
       subsections:
-        - title: # Title for subsection
+        - title: Eleventy documentation
           items:
-          - text: # Title of link in subsection
-            href: # URL for link in subsection
+          - text: Front matter data
+            href: https://www.11ty.dev/docs/data-frontmatter/
 ```
 
-View [the source for this page]({{ viewSource }}) on GitHub
+{% from "govuk/components/details/macro.njk" import govukDetails %}
+{% set detailsText %}{% include "../includes/front-matter-options.md" %}{% endset %}
+{{ govukDetails({
+  summaryText: "Common front matter options",
+  html: detailsText
+}) }}
+
+In addition to the common front matter options, this layout also accepts the following options:
+
+| Name | Type | Description |
+| :--- | :--- | :---------- |
+| **author** | string&nbsp;or&nbsp;object | Post author. |
+| **author.name** | string | Name of post author. Overrides any single value given for author. |
+| **author.url** | string | URL for website of post author. |
+| **authors** | array | Post authors. Overrides any value(s) given for author. |
+| **authors.name** | string | Name of post author. |
+| **authors.url** | string | URL for website of post author. |
+| **date** | string | Date post was published. Use [ISO 8601 format](https://en.wikipedia.org/wiki/ISO_8601), for example `{{ "now" | date("yyyy-MM-dd") }}`. |
+| **image** | object | Image shown above post content. |
+| **image.src** | string | Path to post image. |
+| **image.alt** | string | Alternative text for post image. |
+| **image.caption** | string | Caption shown below post image. |
+| **image.ogImage** | boolean | Whether image should also be used as the page’s Open Graph share image. |

--- a/docs/layouts/product.md
+++ b/docs/layouts/product.md
@@ -2,8 +2,10 @@
 layout: product
 order: 5
 title: Product page
-description: Layout for a product or marketing page.
-startButton: true
+description: Layout for a product or marketing page based on the [Product Page Example](https://github.com/alphagov/product-page-example).
+startButton:
+  href: "#"
+  text: Start button
 image:
   src: /assets/homepage-illustration.png
   alt: The Eleventy mascot floating above a laptop.
@@ -21,37 +23,52 @@ related:
           - text: Front matter data
             href: https://www.11ty.dev/docs/data-frontmatter/
 ---
-The `product` layout is designed for home and product pages, based on [Product Page Example](https://github.com/alphagov/product-page-example).
+Use front matter options to customise the appearance, content and behaviour of this layout.
 
-## Front matter properties
+For example, this page has the following options:
 
 ```yaml
 layout: product
-includeInBreadcrumbs: # Show link to page in any breadcrumbs. Default is `false`
-order: # Adjust position of page in side navigation
-title: # Appears at the top of the page and in the <title>
-description: # Appears below page title and in page <meta>
-startButton: # Optional
-  text: # Label for start button
-  href: # Link for start button
+order: 5
+title: Product page
+description: Layout for a product or marketing page based on the [Product Page Example](https://github.com/alphagov/product-page-example).
+startButton:
+  href: "#"
+  text: Start button
 image:
-  src: # Image source path for hero image.
-  alt: # Textual alternative for hero image.
-  ogImage: # Boolean. Whether to use image as share image as well
-ogImage: # Open Graph image. Overrides image (if image.ogImage is true)
-  src: # Image shown when sharing post
-  alt: # Alternative text for share image
-related: # Related links (appears below content)
+  src: /assets/homepage-illustration.png
+  alt: Eleventy’s possum mascot hanging on a red balloon and floating above a laptop.
+related:
   sections:
-    - title: # Default is ‘Related content’
+    - title: Related links
       items:
-        - text: # Title of related link
-          href: # URL for related link
+        - text: Layouts
+          href: ../../layouts
+        - text: Options
+          href: ../../options
       subsections:
-        - title: # Title for subsection
+        - title: Eleventy documentation
           items:
-          - text: # Title of link in subsection
-            href: # URL for link in subsection
+          - text: Front matter data
+            href: https://www.11ty.dev/docs/data-frontmatter/
 ```
 
-View [the source for this page]({{ viewSource }}) on GitHub
+{% from "govuk/components/details/macro.njk" import govukDetails %}
+{% set detailsText %}{% include "../includes/front-matter-options.md" %}{% endset %}
+{{ govukDetails({
+  summaryText: "Common front matter options",
+  html: detailsText
+}) }}
+
+### Additional front matter options
+
+In addition to the common front matter options, this layout also has the following options:
+
+| Name | Type | Description |
+| :--- | :--- | :---------- |
+| **startButton** | string | Start button. Appears below the title and any description. |
+| **startButton.text** | string | Text for the start button. Default is `'Get started'`. |
+| **startButton.href** | string | The URL that the start button should link to. |
+| **image** | object | Product image. Appears to the right of the page title, and is hidden on mobile. |
+| **image.src** | string | Path to product image. |
+| **image.alt** | string | Alternative text for product image. |

--- a/docs/layouts/side-navigation.md
+++ b/docs/layouts/side-navigation.md
@@ -2,7 +2,7 @@
 layout: side-navigation
 order: 2
 title: Page with side navigation
-description: Layout for a page with side navigation.
+description: Layout with side navigation.
 related:
   sections:
     - title: Related links
@@ -17,30 +17,35 @@ related:
           - text: Front matter data
             href: https://www.11ty.dev/docs/data-frontmatter/
 ---
-The `side-navigation` layout is with navigation on the left side of the page.
+The `side-navigation` layout offers a page with navigation to the left of its content.
 
-## Front matter properties
+Use front matter options to customise the appearance, content and behaviour of this layout.
+
+For example, this page has the following options:
 
 ```yaml
-layout: page
-includeInBreadcrumbs: # Show link to page in any breadcrumbs. Default is `false`
-order: # Adjust position of page in side navigation
-title: # Appears at the top of the page and in the <title>
-description: # Appears below page title and in page <meta>
-ogImage: # Open Graph image
-  src: # Image shown when sharing post
-  alt: # Alternative text for share image
-related: # Related links (appears below content)
+layout: side-navigation
+order: 2
+title: Page with side navigation
+description: Layout with side navigation.
+related:
   sections:
-    - title: # Default is ‘Related content’
+    - title: Related links
       items:
-        - text: # Title of related link
-          href: # URL for related link
+        - text: Layouts
+          href: ../../layouts
+        - text: Options
+          href: ../../options
       subsections:
-        - title: # Title for subsection
+        - title: Eleventy documentation
           items:
-          - text: # Title of link in subsection
-            href: # URL for link in subsection
+          - text: Front matter data
+            href: https://www.11ty.dev/docs/data-frontmatter/
 ```
 
-View [the source for this page]({{ viewSource }}) on GitHub
+{% from "govuk/components/details/macro.njk" import govukDetails %}
+{% set detailsText %}{% include "../includes/front-matter-options.md" %}{% endset %}
+{{ govukDetails({
+  summaryText: "Common front matter options",
+  html: detailsText
+}) }}


### PR DESCRIPTION
Improved documentation for available front matter options for layouts. Also adds an include so that common layout options can be updated in one places and repeated across all layouts.