### PR TITLE
Refactor frontend JavaScript imports

### DIFF
--- a/components/all.js
+++ b/components/all.js
@@ -1,57 +1,13 @@
 import SiteSearch from './site-search/site-search.js'
 
 /**
- * Get module name.
- *
- * @example
- * _getModuleName(selectable-table) // SelectableTable
- *
- * @access private
- * @param {string} string - Original value
- * @returns {string} data Updated data
+ * Initiate all component modules
  */
-const _getModuleName = (string) => {
-  // Convert string to camel case
-  string = string.replace(/-([a-z])/g, (g) => g.charAt(1).toUpperCase())
+export const initAll = function () {
+  const scope = document.documentElement
 
-  // Capitalise first letter
-  string = string.charAt(0).toUpperCase() + string.slice(1)
-
-  return string
+  const siteSearch = scope.querySelectorAll('[data-module="app-site-search"]')
+  siteSearch.forEach(element => {
+    new SiteSearch(element).init()
+  })
 }
-
-/**
- * Find and initiate component modules.
- *
- * @example
- * [data-module="foo-bar"] initiates GOVUK11ty.FooBar()
- */
-export const components = (function () {
-  const GOVUK11ty = window.GOVUK11ty || {}
-
-  // Initiate all component modules
-  GOVUK11ty.initAll = function (container) {
-    container = container || document.documentElement
-    const modules = container.querySelectorAll('[data-module]')
-
-    modules.forEach((module, i) => {
-      const element = modules[i]
-      const name = _getModuleName(element.dataset.module)
-      const started = element.dataset.moduleStarted
-
-      if (typeof GOVUK11ty[name] === 'function' && !started) {
-        module = new GOVUK11ty[name]()
-        module.start(element)
-        element.dataset.moduleStarted = true
-      }
-    })
-  }
-
-  // Add component modules to GOVUK11ty object
-  GOVUK11ty.SiteSearch = SiteSearch
-
-  // Add GOVUK11ty to window global
-  window.GOVUK11ty = GOVUK11ty
-
-  return GOVUK11ty
-})()

--- a/components/site-search/template.njk
+++ b/components/site-search/template.njk
@@ -1,4 +1,4 @@
-<div class="app-site-search govuk-!-display-none-print" data-module="app-search" data-search-index="{{ params.indexPath | url }}">
+<div class="app-site-search govuk-!-display-none-print" data-module="app-site-search" data-search-index="{{ params.indexPath | url }}">
   <label class="govuk-visually-hidden" for="app-site-search__input">{{ params.label | default("Search site") }}</label>
   <a class="app-site-search__link govuk-link-no-visited" href="{{ params.sitemapPath | url }}">Sitemap</a>
 </div>

--- a/layouts/base.njk
+++ b/layouts/base.njk
@@ -63,10 +63,6 @@
 
 {% block bodyEnd %}
   <script src="{{ '/assets/govuk.js' | url }}"></script>
-  <script>
-    document.documentElement.classList.remove('no-js')
-    const searchContainer = document.querySelector('[data-module="app-search"]')
-    new GOVUK11ty.SiteSearch(searchContainer).init()
-  </script>
+  <script>document.documentElement.classList.remove('no-js')</script>
   {% block scripts %}{% endblock %}
 {% endblock %}

--- a/lib/govuk.js
+++ b/lib/govuk.js
@@ -2,10 +2,10 @@
 import { initAll as GOVUKFrontend } from 'govuk-frontend'
 
 // Import plugin components
-import { components as GOVUK11ty } from '../components/all.js'
+import { initAll as GOVUK11ty } from '../components/all.js'
 
 // Initiate scripts on page load
 document.addEventListener('DOMContentLoaded', () => {
   GOVUKFrontend()
-  GOVUK11ty.initAll()
+  GOVUK11ty()
 })

--- a/lib/govuk.js
+++ b/lib/govuk.js
@@ -1,11 +1,11 @@
 // Import GOV.UK Frontend
-import GOVUKFrontend from 'govuk-frontend'
+import { initAll as GOVUKFrontend } from 'govuk-frontend'
 
 // Import plugin components
 import { components as GOVUK11ty } from '../components/all.js'
 
 // Initiate scripts on page load
 document.addEventListener('DOMContentLoaded', () => {
-  GOVUKFrontend.initAll()
+  GOVUKFrontend()
   GOVUK11ty.initAll()
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@rollup/plugin-commonjs": "^22.0.0",
         "@rollup/plugin-node-resolve": "^13.1.1",
         "deepmerge": "^4.2.2",
-        "govuk-frontend": "4.0.1",
+        "govuk-frontend": "^4.1.0",
         "govuk-prototype-components": "^0.1.5",
         "luxon": "^2.1.1",
         "markdown-it-abbr": "^1.0.4",
@@ -3456,9 +3456,9 @@
       "link": true
     },
     "node_modules/govuk-frontend": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.0.1.tgz",
-      "integrity": "sha512-X+B88mqYHoxAz0ID87Uxo3oHqdKBRnNHd3Cz8+u8nvQUAsrEzROFLK+t7sAu7e+fKqCCrJyIgx6Cmr6dIGnohQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.1.0.tgz",
+      "integrity": "sha512-xBUUarxinGWSccmXPmwa7ovg3xabEQ0+Dcv7pdq9X3F69892OFMqP2g8jvlDUrVsDVdasXLk4Jq4w8dPiaEVqQ==",
       "engines": {
         "node": ">= 4.2.0"
       }
@@ -11168,7 +11168,7 @@
         "c8": "^7.11.0",
         "deepmerge": "^4.2.2",
         "govuk-eleventy-plugin": "file:",
-        "govuk-frontend": "4.0.1",
+        "govuk-frontend": "^4.1.0",
         "govuk-prototype-components": "^0.1.5",
         "luxon": "^2.1.1",
         "markdown-it-abbr": "^1.0.4",
@@ -13779,9 +13779,9 @@
           "dev": true
         },
         "govuk-frontend": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.0.1.tgz",
-          "integrity": "sha512-X+B88mqYHoxAz0ID87Uxo3oHqdKBRnNHd3Cz8+u8nvQUAsrEzROFLK+t7sAu7e+fKqCCrJyIgx6Cmr6dIGnohQ=="
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.1.0.tgz",
+          "integrity": "sha512-xBUUarxinGWSccmXPmwa7ovg3xabEQ0+Dcv7pdq9X3F69892OFMqP2g8jvlDUrVsDVdasXLk4Jq4w8dPiaEVqQ=="
         },
         "govuk-prototype-components": {
           "version": "0.1.5",
@@ -17545,9 +17545,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.0.1.tgz",
-      "integrity": "sha512-X+B88mqYHoxAz0ID87Uxo3oHqdKBRnNHd3Cz8+u8nvQUAsrEzROFLK+t7sAu7e+fKqCCrJyIgx6Cmr6dIGnohQ=="
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.1.0.tgz",
+      "integrity": "sha512-xBUUarxinGWSccmXPmwa7ovg3xabEQ0+Dcv7pdq9X3F69892OFMqP2g8jvlDUrVsDVdasXLk4Jq4w8dPiaEVqQ=="
     },
     "govuk-prototype-components": {
       "version": "0.1.5",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@rollup/plugin-commonjs": "^22.0.0",
     "@rollup/plugin-node-resolve": "^13.1.1",
     "deepmerge": "^4.2.2",
-    "govuk-frontend": "4.0.1",
+    "govuk-frontend": "^4.1.0",
     "govuk-prototype-components": "^0.1.5",
     "luxon": "^2.1.1",
     "markdown-it-abbr": "^1.0.4",


### PR DESCRIPTION
GOV.UK Frontend v4.1.0 now uses a named export, which breaks the previous implementation, worryingly.

This PR updates how we import the `initAll()` function by using this named export and aliasing it to `GOVUKFrontend()`.

It also updates how we import the components used by the plugin (of which there is only one, currently) so that the APIs match.

Fixes #43.