### PR TITLE
Make sections within related items optional

### DIFF
--- a/docs/includes/front-matter-options.md
+++ b/docs/includes/front-matter-options.md
@@ -14,14 +14,21 @@ Use these options to customise the appearance, content and behaviour of any layo
 
 ### Options for related
 
+With one section:
+
 | Name | Type | Description |
 | :--- | :--- | :---------- |
-| **sections** | array | |
-| **sections.title** | string | Title for group of related links. Default is `'Related content'`. |
-| **sections.items** | array | See [items](#options-for-items). |
-| **sections.subsections** | array | Title for sub-group of related links. |
-| **sections.subsections.title** | string | |
-| **sections.subsections.items** | array | See [items](#options-for-items). |
+| **title** | string | Title for group of related links. Default is `'Related content'`. |
+| **items** | array | See [items](#options-for-items). |
+| **subsections** | array | Title for sub-group of related links. |
+| **subsections.title** | string | |
+| **subsections.items** | array | See [items](#options-for-items). |
+
+With multiple sections:
+
+| Name | Type | Description |
+| :--- | :--- | :---------- |
+| **sections** | array | See [items](#options-for-related). |
 
 ### Options for items
 

--- a/layouts/collection.njk
+++ b/layouts/collection.njk
@@ -49,9 +49,13 @@
           }) }}
         </section>
 
-        {% if related.sections[0].items | length > 0 %}
+        {#- Related items may contain many sections or none -#}
+        {%- set sections = related.sections or [related] -%}
+        {% if related.sections or related.items | length > 0 %}
         <div class="govuk-grid-column-one-third">
-          {{ xGovukRelatedNavigation(related) }}
+          {{ xGovukRelatedNavigation({
+            sections: sections
+          }) }}
         </div>
         {% endif %}
       </div>

--- a/layouts/page.njk
+++ b/layouts/page.njk
@@ -17,5 +17,9 @@
     {{ content }}
   {% endcall %}
 
-  {{ xGovukRelatedNavigation(related) if related.sections[0].items | length > 0 }}
+  {#- Related items may contain many sections or none -#}
+  {%- set sections = related.sections or [related] -%}
+  {{ xGovukRelatedNavigation({
+    sections: sections
+  }) if related.sections or related.items | length > 0 }}
 {% endblock %}

--- a/layouts/post.njk
+++ b/layouts/post.njk
@@ -26,9 +26,13 @@
       {% endcall %}
     </div>
 
-    {% if related.sections[0].items | length > 0 %}
+    {#- Related items may contain many sections or none -#}
+    {%- set sections = related.sections or [related] -%}
+    {% if related.sections or related.items | length > 0 %}
     <div class="govuk-grid-column-one-third">
-      {{ xGovukRelatedNavigation(related) }}
+      {{ xGovukRelatedNavigation({
+        sections: sections
+      }) }}
     </div>
     {% endif %}
   </div>

--- a/layouts/product.njk
+++ b/layouts/product.njk
@@ -32,7 +32,11 @@
       {% endcall %}
     {% endblock %}
 
-    {{ xGovukRelatedNavigation(related) if related.sections[0].items | length > 0 }}
+    {#- Related items may contain many sections or none -#}
+    {%- set sections = related.sections or [related] -%}
+    {{ xGovukRelatedNavigation({
+      sections: sections
+    }) if related.sections or related.items | length > 0 }}
     </main>
   </div>
 {% endblock %}

--- a/layouts/side-navigation.njk
+++ b/layouts/side-navigation.njk
@@ -24,7 +24,11 @@
         {{ content }}
       {% endcall %}
 
-      {{ xGovukRelatedNavigation(related) if related.sections[0].items | length > 0 }}
+      {#- Related items may contain many sections or none -#}
+      {%- set sections = related.sections or [related] -%}
+      {{ xGovukRelatedNavigation({
+        sections: sections
+      }) if related.sections or related.items | length > 0 }}
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
Related items can have multiple sections, or none. So either:

```yaml
related:
  sections: 
    - title: …
      items: …
      subsections: …
    - title: …
      items: …
      subsections: …
```

or:

```yaml
related:
  title: …
  items: …
  subsections: …
```
