### PR TITLE
Add ability to show content aside main body of a document

### DIFF
--- a/components/all.scss
+++ b/components/all.scss
@@ -1,4 +1,5 @@
 @import "article/article";
+@import "aside/aside";
 @import "contents-list/contents-list";
 @import "definition-list/definition-list";
 @import "document-list/document-list";

--- a/components/aside/_aside.scss
+++ b/components/aside/_aside.scss
@@ -1,0 +1,17 @@
+.app-aside {
+  @include govuk-responsive-margin(6, "bottom");
+  @include govuk-text-colour;
+  border-top: 2px solid $govuk-brand-colour;
+}
+
+.app-aside__heading {
+  @include govuk-font(19, $weight: bold);
+  margin-top: govuk-spacing(3);
+  margin-bottom: govuk-spacing(2);
+}
+
+.app-aside__body {
+  > * {
+    @include govuk-font(16);
+  }
+}

--- a/components/aside/macro.njk
+++ b/components/aside/macro.njk
@@ -1,0 +1,3 @@
+{% macro appAside(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/components/aside/template.njk
+++ b/components/aside/template.njk
@@ -1,0 +1,13 @@
+{% set headingLevel = params.headingLevel or 2 %}
+
+<aside class="app-aside">
+  {% if params.title %}
+  <h{{ headingLevel }} class="app-aside__heading">
+    {{ params.title }}
+  </h{{ headingLevel }}>
+  {% endif %}
+
+  <div class="app-aside__body">
+    {{ params.content | markdown }}
+  </div>
+</aside>

--- a/docs/includes/front-matter-options.md
+++ b/docs/includes/front-matter-options.md
@@ -10,6 +10,9 @@ Use these options to customise the appearance, content and behaviour of any layo
 | **ogImage** | object | Open Graph image that appears on social media networks. |
 | **ogImage.src** | string | Path to Open Graph image. Can be a relative or absolute URL. |
 | **ogImage.alt** | string | Alternative text for Open Graph image. |
+| **aside** | object | Small portion of content that is indirectly related to the main content. |
+| **aside.title** | string | Title for aside. |
+| **aside.content** | string | Content for aside. Accepts Markdown. |
 | **related** | object | Related links. See [related](#options-for-related). |
 
 ### Options for related

--- a/docs/layouts/collection.md
+++ b/docs/layouts/collection.md
@@ -18,6 +18,10 @@ example:
       date: 2021-09-08
       title: Helping users better find our service
       description: Reviewing the user onboarding journey.
+aside:
+  title: Aside
+  content: | 
+    A small portion of content that is **indirectly** related to the main content.
 related:
   sections:
     - title: Related links
@@ -56,6 +60,10 @@ example:
       date: 2021-09-08
       title: Helping users better find our service
       description: Reviewing the user onboarding journey.
+aside:
+  title: Aside
+  content: | 
+    A small portion of content that is **indirectly** related to the main content.
 related:
   sections:
     - title: Related links

--- a/docs/layouts/page.md
+++ b/docs/layouts/page.md
@@ -3,6 +3,10 @@ layout: page
 order: 1
 title: Page
 description: Simple layout designed for maximum flexibility of content.
+aside:
+  title: Aside
+  content: | 
+    A small portion of content that is **indirectly** related to the main content.
 related:
   sections:
     - title: Related links
@@ -26,6 +30,10 @@ layout: page
 order: 1
 title: Page
 description: Simple layout designed for maximum flexibility of content.
+aside:
+  title: Aside
+  content: | 
+    A small portion of content that is **indirectly** related to the main content.
 related:
   sections:
     - title: Related links

--- a/docs/layouts/post.md
+++ b/docs/layouts/post.md
@@ -13,6 +13,10 @@ authors:
     url: https://www.gov.uk/government/history/past-prime-ministers/william-ewart-gladstone
   - name: Benjamin Disraeli
     url: https://www.gov.uk/government/history/past-prime-ministers/benjamin-disraeli-the-earl-of-beaconsfield
+aside:
+  title: Aside
+  content: | 
+    A small portion of content that is **indirectly** related to the main content.
 related:
   sections:
     - title: Related links
@@ -46,6 +50,10 @@ authors:
     url: https://www.gov.uk/government/history/past-prime-ministers/william-ewart-gladstone
   - name: Benjamin Disraeli
     url: https://www.gov.uk/government/history/past-prime-ministers/benjamin-disraeli-the-earl-of-beaconsfield
+aside:
+  title: Aside
+  content: | 
+    A small portion of content that is **indirectly** related to the main content.
 related:
   sections:
     - title: Related links

--- a/docs/layouts/product.md
+++ b/docs/layouts/product.md
@@ -9,6 +9,10 @@ startButton:
 image:
   src: /assets/homepage-illustration.png
   alt: The Eleventy mascot floating above a laptop.
+aside:
+  title: Aside
+  content: | 
+    A small portion of content that is **indirectly** related to the main content.
 related:
   sections:
     - title: Related links
@@ -38,6 +42,10 @@ startButton:
 image:
   src: /assets/homepage-illustration.png
   alt: Eleventy’s possum mascot hanging on a red balloon and floating above a laptop.
+aside:
+  title: Aside
+  content: | 
+    A small portion of content that is **indirectly** related to the main content.
 related:
   sections:
     - title: Related links

--- a/docs/layouts/side-navigation.md
+++ b/docs/layouts/side-navigation.md
@@ -3,6 +3,10 @@ layout: side-navigation
 order: 2
 title: Page with side navigation
 description: Layout with side navigation.
+aside:
+  title: Aside
+  content: | 
+    A small portion of content that is **indirectly** related to the main content.
 related:
   sections:
     - title: Related links
@@ -28,6 +32,10 @@ layout: side-navigation
 order: 2
 title: Page with side navigation
 description: Layout with side navigation.
+aside:
+  title: Aside
+  content: | 
+    A small portion of content that is **indirectly** related to the main content.
 related:
   sections:
     - title: Related links

--- a/layouts/base.njk
+++ b/layouts/base.njk
@@ -20,6 +20,7 @@
 {% from "x-govuk/components/side-navigation/macro.njk" import xGovukSideNavigation %}
 
 {% from "components/article/macro.njk" import appArticle %}
+{% from "components/aside/macro.njk" import appAside %}
 {% from "components/document-list/macro.njk" import appDocumentList %}
 {% from "components/footer/macro.njk" import appFooter %}
 {% from "components/header/macro.njk" import appHeader %}

--- a/layouts/collection.njk
+++ b/layouts/collection.njk
@@ -49,9 +49,10 @@
           }) }}
         </section>
 
-        <div class="govuk-grid-column-one-third">
-          {% include "shared/related.njk" %}
-        </div>
+        {% if aside or related %}
+          <div class="govuk-grid-column-one-third">
+            {% include "shared/related.njk" %}
+          </div>
         {% endif %}
       </div>
     {% endblock %}

--- a/layouts/post.njk
+++ b/layouts/post.njk
@@ -26,9 +26,10 @@
       {% endcall %}
     </div>
 
-    <div class="govuk-grid-column-one-third">
-      {% include "shared/related.njk" %}
-    </div>
+    {% if aside or related %}
+      <div class="govuk-grid-column-one-third">
+        {% include "shared/related.njk" %}
+      </div>
     {% endif %}
   </div>
 {% endblock %}

--- a/layouts/shared/related.njk
+++ b/layouts/shared/related.njk
@@ -1,3 +1,5 @@
+{{ appAside(aside) if aside }}
+
 {#- Related items may contain many sections or none -#}
 {%- set sections = related.sections or [related] -%}
 {{ xGovukRelatedNavigation({


### PR DESCRIPTION
Sometimes, the related navigation component doesn’t provide enough flexibility for adding additional content to a page, partially on those layouts where on wider viewports a sidebar is shown.

An example of this need can be seen in many design histories where a link to a prototype, alongside its username and password, are presented alongside other links:

<img width="1020" alt="Screenshot 2022-05-23 at 19 36 36" src="https://user-images.githubusercontent.com/813383/169884874-69c26682-60c8-4dff-aa59-e2d0de8e33b7.png">

We could update the related navigation component to accept additional descriptive text for links, but that would introduce a difference from [the GOV.UK publishing component](https://components.publishing.service.gov.uk/component-guide/related_navigation) it is based on.

## Proposed solution

Adds a new `aside` area of each layout, which accepts `title` and `content` values. The aside is styled to match the design of the related navigation component, should both be shown at the same time.

### Collection

Shown in the sidebar on wider layouts.

<img width="1020" alt="Screenshot 2022-05-23 at 19 33 07" src="https://user-images.githubusercontent.com/813383/169884720-8b1db253-cd15-4f8c-9add-596eb0179798.png">

### Post

Shown in the sidebar on wider layouts.

<img width="1020" alt="Screenshot 2022-05-23 at 19 34 04" src="https://user-images.githubusercontent.com/813383/169884741-cd7991b2-0a59-4e12-817d-0bfb623b0257.png">

### Other layouts

Always shown below the main content.

<img width="1019" alt="Screenshot 2022-05-23 at 19 34 21" src="https://user-images.githubusercontent.com/813383/169884759-fb1bd907-2627-40c7-a77c-83bc363bd538.png">

Additional configuration options can be added later, if required, but best to start simple.