### PR TITLE
If the current page is in the navigation, do not link to it

### DIFF
--- a/lib/filters/items-from-navigation.js
+++ b/lib/filters/items-from-navigation.js
@@ -14,19 +14,28 @@ module.exports = (eleventyNavigation, pageUrl = false, options = {}) => {
   const currentUrl = pageUrl ? url(pageUrl, pathPrefix) : false
   const items = []
 
-  eleventyNavigation.map(item => items.push({
-    current: pageUrl ? url(item.url, pathPrefix) === currentUrl : false,
-    parent: pageUrl ? pageUrl.startsWith(item.url, pathPrefix) : false,
-    href: url(item.url, pathPrefix),
-    text: item.title,
-    children: item.children
-      ? item.children.map(child => ({
-        current: pageUrl ? url(child.url, pathPrefix) === currentUrl : false,
-        href: url(child.url, pathPrefix),
-        text: child.title
-      }))
-      : false
-  }))
+  eleventyNavigation.map(item => {
+    const isCurrentPage = pageUrl && url(item.url, pathPrefix) === currentUrl
+    const navItem = {
+      current: isCurrentPage,
+      parent: pageUrl ? pageUrl.startsWith(item.url, pathPrefix) : false,
+      text: item.title,
+      children: item.children
+        ? item.children.map(child => ({
+          current: pageUrl ? url(child.url, pathPrefix) === currentUrl : false,
+          href: url(child.url, pathPrefix),
+          text: child.title
+        }))
+        : false
+    }
+
+    // If the current page is being shown in the navigation, do not link to it
+    if (!isCurrentPage) {
+      navItem.href = url(item.url, pathPrefix)
+    }
+
+    items.push(navItem)
+  })
 
   if (options?.parentSite) {
     items.unshift({

--- a/lib/filters/items-from-navigation.js
+++ b/lib/filters/items-from-navigation.js
@@ -14,7 +14,7 @@ module.exports = (eleventyNavigation, pageUrl = false, options = {}) => {
   const currentUrl = pageUrl ? url(pageUrl, pathPrefix) : false
   const items = []
 
-  eleventyNavigation.map(item => {
+  eleventyNavigation.forEach(item => {
     const isCurrentPage = pageUrl && url(item.url, pathPrefix) === currentUrl
     const navItem = {
       current: isCurrentPage,

--- a/tests/lib/filters/items-from-navigation.mjs
+++ b/tests/lib/filters/items-from-navigation.mjs
@@ -28,10 +28,20 @@ const eleventyNavigationBreadcrumb = [{
     title: 'Child page',
     _isBreadcrumb: true
   }]
+}, {
+  key: 'child',
+  parent: 'parent',
+  excerpt: false,
+  url: '/parent/child',
+  pluginType: 'eleventy-navigation',
+  parentKey: 'parent',
+  title: 'Child page',
+  _isBreadcrumb: true,
+  children: false
 }]
 
 test('Converts navigation data to items array', t => {
-  const result = itemsFromNavigation(eleventyNavigationBreadcrumb, '/parent/')
+  const result = itemsFromNavigation(eleventyNavigationBreadcrumb, '/parent/child')
 
   t.deepEqual(result, [{
     href: '/',
@@ -42,13 +52,18 @@ test('Converts navigation data to items array', t => {
   }, {
     href: '/parent/',
     text: 'Parent page',
-    current: true,
+    current: false,
     parent: true,
     children: [{
       href: '/parent/child/',
       text: 'Child page',
       current: false
     }]
+  }, {
+    text: 'Child page',
+    current: true,
+    parent: true,
+    children: false
   }])
 })
 
@@ -71,6 +86,12 @@ test('Converts navigation data to items array without page URL', t => {
       text: 'Child page',
       current: false
     }]
+  }, {
+    href: '/parent/child',
+    text: 'Child page',
+    current: false,
+    parent: false,
+    children: false
   }])
 })
 
@@ -78,7 +99,7 @@ test('Converts navigation data to items array using path prefix', t => {
   const config = {
     pathPrefix: '/prefix/'
   }
-  const result = itemsFromNavigation(eleventyNavigationBreadcrumb, '/parent/', config)
+  const result = itemsFromNavigation(eleventyNavigationBreadcrumb, '/parent/child', config)
 
   t.deepEqual(result, [{
     href: '/prefix/',
@@ -89,13 +110,18 @@ test('Converts navigation data to items array using path prefix', t => {
   }, {
     href: '/prefix/parent/',
     text: 'Parent page',
-    current: true,
+    current: false,
     parent: true,
     children: [{
       href: '/prefix/parent/child/',
       text: 'Child page',
       current: false
     }]
+  }, {
+    text: 'Child page',
+    current: true,
+    parent: true,
+    children: false
   }])
 })
 
@@ -106,7 +132,7 @@ test('Converts navigation data to items array adding parent site', t => {
       name: 'Example'
     }
   }
-  const result = itemsFromNavigation(eleventyNavigationBreadcrumb, '/parent/', config)
+  const result = itemsFromNavigation(eleventyNavigationBreadcrumb, '/parent/child', config)
 
   t.deepEqual(result, [{
     href: 'https://example.org',
@@ -120,13 +146,18 @@ test('Converts navigation data to items array adding parent site', t => {
   }, {
     href: '/parent/',
     text: 'Parent page',
-    current: true,
+    current: false,
     parent: true,
     children: [{
       href: '/parent/child/',
       text: 'Child page',
       current: false
     }]
+  }, {
+    text: 'Child page',
+    current: true,
+    parent: true,
+    children: false
   }])
 })
 
@@ -138,7 +169,7 @@ test('Converts navigation data to items array adding parent site and using path 
     },
     pathPrefix: '/prefix/'
   }
-  const result = itemsFromNavigation(eleventyNavigationBreadcrumb, '/parent/', config)
+  const result = itemsFromNavigation(eleventyNavigationBreadcrumb, '/parent/child', config)
 
   t.deepEqual(result, [{
     href: 'https://example.org',
@@ -152,12 +183,17 @@ test('Converts navigation data to items array adding parent site and using path 
   }, {
     href: '/prefix/parent/',
     text: 'Parent page',
-    current: true,
+    current: false,
     parent: true,
     children: [{
       href: '/prefix/parent/child/',
       text: 'Child page',
       current: false
     }]
+  }, {
+    text: 'Child page',
+    current: true,
+    parent: true,
+    children: false
   }])
 })


### PR DESCRIPTION
When using the `includeInBreadcrumbs` option, the current page gets shown as the last item in the breadcrumb.

Currently it shows as a link to itself and there is no indication that it is the current page.

In this change, if the current page is in the navigation, no href is included, so the page does not get linked to by the breadcrumb component.

This creates 2 options for breadcrumbs:

1. Hide the current page, only show the parents (current design system recommendation)
2. Show the current page, and indicate that it's the current page by not making it a link (previous design system recommendation)

I've extended the breadcrumb in the test fixture to be 3 items long so the href logic can continue to be tested on a breadcrumb that is not the current.

| Before | After |
|--|--|
| ![Screenshot 2022-05-25 at 09 44 44](https://user-images.githubusercontent.com/319055/170221128-09af299b-6bd7-42a2-bd5d-6ccdec70612d.png) |  ![Screenshot 2022-05-25 at 09 44 27](https://user-images.githubusercontent.com/319055/170221135-9d868ce3-1612-40da-aeae-42dfbcfeba40.png) |



