### PR TITLE
Remove top margin from document list on collections

### DIFF
--- a/layouts/collection.njk
+++ b/layouts/collection.njk
@@ -32,7 +32,7 @@
           {% endif %}
           {{ appDocumentList({
             headingLevel: 3 if paginationHeading else 2,
-            classes: "app-document-list--large",
+            classes: "app-document-list--large govuk-!-margin-top-0",
             items: pagination.items
           }) }}
           {{ appPagination({


### PR DESCRIPTION
- If the document list is the only item, there's an unnecessary margin which means it does not line up with related content
- If it is no the only item, the margins from article and pagination headings give the correct gap

| Before | After |
|--|--|
| ![Screenshot 2022-06-01 at 15 26 32](https://user-images.githubusercontent.com/319055/171428676-4c6a8518-46ad-4081-aa5f-71eeea4a2372.png) | ![Screenshot 2022-06-01 at 15 26 23](https://user-images.githubusercontent.com/319055/171428685-43563f48-41c4-4944-8fc7-33394b4ad85a.png) |