### PR TITLE
Correct location for OGL licence logo. Fixes #50

### DIFF
--- a/components/footer/template.njk
+++ b/components/footer/template.njk
@@ -50,8 +50,8 @@
           {% endif %}
         {% endif %}
         {% if params.licence == "ogl" %}
+          {% include "./_ogl.svg" %}
           <span class="govuk-footer__licence-description">
-            {% include "./_ogl.svg" %}
             All content is available under the <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated
           </span>
         {% elif params.licence %}


### PR DESCRIPTION
Logo shouldn’t be nested within `govuk-footer__licence-description`.