### PR TITLE
Allow full override of product layout content

### DIFF
--- a/layouts/product.njk
+++ b/layouts/product.njk
@@ -28,9 +28,9 @@
     <main class="govuk-main-wrapper {{ mainClasses }}" id="main-content" role="main"{% if mainLang %} lang="{{ mainLang }}"{% endif %}>
       {% block content %}
         {{ appProseScope(content) if content }}
-      {% endblock %}
 
-      {% include "layouts/shared/related.njk" %}
+        {% include "layouts/shared/related.njk" %}
+      {% endblock %}
     </main>
   </div>
 {% endblock %}


### PR DESCRIPTION
Fixes https://github.com/x-govuk/govuk-design-history/issues/152

Given the intended flexibility of this layout (everything below the masthead is free game), we probably ought to allow authors to override the related components as well.