### PR TITLE
Consistently use ‘smart’ punctuation for document titles

### DIFF
--- a/components/document-header/template.njk
+++ b/components/document-header/template.njk
@@ -1,6 +1,6 @@
 <header class="app-document-header">
   <h1 class="app-document-header__title govuk-heading-xl">
-    {{ params.title | markdown("inline") }}
+    {{ params.title | smart }}
   </h1>
   {% if params.description %}
     <p class="app-document-header__description govuk-body-l">

--- a/components/document-list/template.njk
+++ b/components/document-list/template.njk
@@ -5,7 +5,7 @@
   {% for item in params.items %}
     <li class="app-document-list__item">
       <h{{ headingLevel }} class="app-document-list__item-title">
-        <a class="govuk-link" href="{{ item.url | url | pretty }}">{{ item.data.title }}</a>
+        <a class="govuk-link" href="{{ item.url | url | pretty }}">{{ item.data.title | smart }}</a>
       </h{{ headingLevel }}>
       {% if item.data.description %}
       <p class="app-document-list__item-description">

--- a/components/footer/template.njk
+++ b/components/footer/template.njk
@@ -56,7 +56,7 @@
           </span>
         {% elif params.licence %}
           <span class="govuk-footer__licence-description">
-            {{ params.licence | markdown("inline") | replace("govuk-link", "govuk-footer__link") }}
+            {{ params.licence | smart | replace("govuk-link", "govuk-footer__link") }}
           </span>
         {% endif %}
       </div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,9 +16,9 @@ eleventyComputed:
 <div class="govuk-grid-row">
 {% for item in collections["homepage"] %}
   <section class="govuk-grid-column-one-third-from-desktop govuk-!-margin-bottom-8">
-    <h2 class="govuk-heading-m govuk-!-font-size-27">{{ item.data.title }}</h2>
+    <h2 class="govuk-heading-m govuk-!-font-size-27">{{ item.data.title | smart }}</h2>
     <p class="govuk-body">{{ item.data.description | markdown("inline") }}</p>
-    <p class="govuk-body"><a class="govuk-link govuk-!-font-weight-bold" href="{{ item.url | url }}">Learn about {{ item.data.title | lower }}</a></p>
+    <p class="govuk-body"><a class="govuk-link govuk-!-font-weight-bold" href="{{ item.url | url }}">Learn about {{ item.data.title | smart | lower }}</a></p>
   </section>
 {% endfor %}
   <section class="govuk-grid-column-full">

--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ module.exports = function (eleventyConfig, pluginOptions = {}) {
   eleventyConfig.addFilter('markdown', require('./lib/filters/markdown.js'))
   eleventyConfig.addFilter('noOrphans', require('./lib/filters/no-orphans.js'))
   eleventyConfig.addFilter('pretty', require('./lib/filters/pretty.js'))
+  eleventyConfig.addFilter('smart', require('./lib/filters/smart.js'))
   eleventyConfig.addFilter('tokenize', require('./lib/filters/tokenize.js'))
 
   // Layouts aliases

--- a/layouts/collection.njk
+++ b/layouts/collection.njk
@@ -3,7 +3,7 @@
 {% block main %}
   {{ xGovukMasthead({
     title: {
-      html: title
+      html: title | smart
     } if title,
     description: {
       html: description | markdown("inline") | noOrphans

--- a/layouts/product.njk
+++ b/layouts/product.njk
@@ -4,7 +4,7 @@
   {{ xGovukMasthead({
     classes: "x-govuk-masthead--large",
     title: {
-      html: title
+      html: title | smart
     } if title,
     description: {
       html: description | markdown("inline") | noOrphans

--- a/layouts/sitemap.njk
+++ b/layouts/sitemap.njk
@@ -27,7 +27,7 @@
     {% for item in collections.sitemap | eleventyNavigation(options.homeKey) %}
       <div class="govuk-!-margin-bottom-4">
         <h2 class="govuk-heading-s govuk-!-margin-bottom-1">
-          <a class="govuk-link" href="{{ item.url | url | pretty }}">{{ item.title }}</a>
+          <a class="govuk-link" href="{{ item.url | url | pretty }}">{{ item.title | smart }}</a>
         </h2>
         {% if item.excerpt %}
           <p class="govuk-body">{{ item.excerpt | markdown("inline") | striptags(true) }}</p>

--- a/lib/filters/items-from-collection.js
+++ b/lib/filters/items-from-collection.js
@@ -1,3 +1,5 @@
+const smart = require('./smart.js')
+
 /**
  * Transform list of posts in a collection to `items` array that can be
  * consumed by GOV.UK Frontend components
@@ -7,7 +9,7 @@
  */
 module.exports = (array) => {
   return array.map(item => ({
-    text: item.data.title,
+    text: smart(item.data.title),
     href: item.data.url
   }))
 }

--- a/lib/filters/items-from-navigation.js
+++ b/lib/filters/items-from-navigation.js
@@ -1,4 +1,5 @@
 const url = require('@11ty/eleventy/src/Filters/Url.js')
+const smart = require('./smart.js')
 
 /**
  * Transform Eleventy navigation data to `items` array that can be
@@ -19,12 +20,12 @@ module.exports = (eleventyNavigation, pageUrl = false, options = {}) => {
     const navItem = {
       current: isCurrentPage,
       parent: pageUrl ? pageUrl.startsWith(item.url, pathPrefix) : false,
-      text: item.title,
+      text: smart(item.title),
       children: item.children
         ? item.children.map(child => ({
           current: pageUrl ? url(child.url, pathPrefix) === currentUrl : false,
           href: url(child.url, pathPrefix),
-          text: child.title
+          text: smart(child.title)
         }))
         : false
     }
@@ -40,7 +41,7 @@ module.exports = (eleventyNavigation, pageUrl = false, options = {}) => {
   if (options?.parentSite) {
     items.unshift({
       href: options.parentSite.url,
-      text: options.parentSite.name
+      text: smart(options.parentSite.name)
     })
   }
 

--- a/lib/filters/smart.js
+++ b/lib/filters/smart.js
@@ -1,0 +1,17 @@
+const normalise = require('../utils.js')
+const smartypants = require('smartypants')
+
+/**
+ * Convert ASCII punctuation characters into ‘smart’ typographic equivalents.
+ *
+ * @example
+ * smart('Her Majesty\'s Government') // Her Majesty’s Government
+ *
+ * @param {string} string - Value to transform
+ * @return {string} - `string` with smart typographic punctuation
+ */
+module.exports = (string) => {
+  string = normalise(string, '')
+
+  return smartypants.smartypantsu(string, 2)
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,8 @@
         "markdown-it-table-of-contents": "^0.6.0",
         "rimraf": "^3.0.2",
         "rollup": "^2.62.0",
-        "sass": "^1.45.1"
+        "sass": "^1.45.1",
+        "smartypants": "^0.1.6"
       },
       "devDependencies": {
         "ava": "^4.0.1",
@@ -6996,6 +6997,15 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/smartypants": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/smartypants/-/smartypants-0.1.6.tgz",
+      "integrity": "sha512-zGXh+Q6Y3OPTLM5x2HxAIkEAj4ZcePftmIOdIYozv2T+m03Sp5R4YppczKuo6IdnSMc99U+Wgvy8Mil0eeep7g==",
+      "bin": {
+        "smartypants": "bin/smartypants.js",
+        "smartypantsu": "bin/smartypantsu.js"
+      }
+    },
     "node_modules/socket.io": {
       "version": "4.5.1",
       "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.5.1.tgz",
@@ -11204,6 +11214,7 @@
         "rimraf": "^3.0.2",
         "rollup": "^2.62.0",
         "sass": "^1.45.1",
+        "smartypants": "*",
         "standard": "^17.0.0",
         "stylelint": "^ 14.6.1",
         "stylelint-config-gds": "^0.2.0"
@@ -16397,6 +16408,11 @@
           "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.5.tgz",
           "integrity": "sha512-8mo9bslnBO3tr5PEVFzMPIWwWnipGS0xVbYf65zxDqfNwmzYn1LpiKNrR6DlClusuvo+hDHd1zKpmfAe83NQSQ=="
         },
+        "smartypants": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/smartypants/-/smartypants-0.1.6.tgz",
+          "integrity": "sha512-zGXh+Q6Y3OPTLM5x2HxAIkEAj4ZcePftmIOdIYozv2T+m03Sp5R4YppczKuo6IdnSMc99U+Wgvy8Mil0eeep7g=="
+        },
         "socket.io": {
           "version": "4.5.1",
           "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.5.1.tgz",
@@ -20159,6 +20175,11 @@
       "version": "1.6.5",
       "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.5.tgz",
       "integrity": "sha512-8mo9bslnBO3tr5PEVFzMPIWwWnipGS0xVbYf65zxDqfNwmzYn1LpiKNrR6DlClusuvo+hDHd1zKpmfAe83NQSQ=="
+    },
+    "smartypants": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/smartypants/-/smartypants-0.1.6.tgz",
+      "integrity": "sha512-zGXh+Q6Y3OPTLM5x2HxAIkEAj4ZcePftmIOdIYozv2T+m03Sp5R4YppczKuo6IdnSMc99U+Wgvy8Mil0eeep7g=="
     },
     "socket.io": {
       "version": "4.5.1",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
     "markdown-it-table-of-contents": "^0.6.0",
     "rimraf": "^3.0.2",
     "rollup": "^2.62.0",
-    "sass": "^1.45.1"
+    "sass": "^1.45.1",
+    "smartypants": "^0.1.6"
   },
   "devDependencies": {
     "ava": "^4.0.1",

--- a/tests/lib/filters/smart.mjs
+++ b/tests/lib/filters/smart.mjs
@@ -1,0 +1,26 @@
+import test from 'ava'
+import smart from '../../../lib/filters/smart.js'
+
+test('Convert plain ASCII quotes into ‘smart’ typographic quotes', t => {
+  const apostrophe = smart('Her Majesty\'s Government')
+  const singleQuote = smart('\'Upstanding\'')
+  const doubleQuote = smart('"Outstanding"')
+
+  t.is(apostrophe, 'Her Majesty’s Government')
+  t.is(singleQuote, '‘Upstanding’')
+  t.is(doubleQuote, '“Outstanding”')
+})
+
+test('Convert multiple ASCII dashes into ‘smart’ typographic dashes', t => {
+  const emDash = smart('---')
+  const enDash = smart('--')
+
+  t.is(emDash, '—')
+  t.is(enDash, '–')
+})
+
+test('Convert 3 ASCII periods into ‘smart’ typographic ellipsis', t => {
+  const result = smart('...')
+
+  t.is(result, '…')
+})


### PR DESCRIPTION
Render text in navigation and collection items using the inline Markdown parser. This fixes #78, but also means page titles when shown in navigation and collection lists will render as they do on page titles.

Now, whether page titles should accept Markdown is another matter (inline code maybe one example), and whether navigation items should be rendered the same way is another question. But given this is likely to be an edge case, and there are likely cases where this may be wanted, think this is okay, at least for now.  