### PR TITLE
Refactor footer options

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -34,8 +34,12 @@ module.exports = function (eleventyConfig) {
     },
     headingPermalinks: true,
     footer: {
-      copyright: '© X-GOVUK',
-      licence: 'Licensed under the [MIT Licence](https://github.com/x-govuk/govuk-eleventy-plugin/blob/main/LICENSE.txt), except where otherwise stated',
+      copyright: {
+        text: '© X-GOVUK'
+      },
+      contentLicence: {
+        html: 'Licensed under the <a class="govuk-footer__link" href="https://github.com/x-govuk/govuk-eleventy-plugin/blob/main/LICENSE.txt">MIT Licence</a>, except where otherwise stated'
+      },
       meta: {
         items: [{
           href: 'https://www.11ty.dev',

--- a/components/footer/template.njk
+++ b/components/footer/template.njk
@@ -49,24 +49,22 @@
             </div>
           {% endif %}
         {% endif %}
-        {% if params.licence == "ogl" %}
+        {% if params.contentLicence.html or params.contentLicence.text %}
+          <span class="govuk-footer__licence-description">
+            {{ params.contentLicence.html | safe if params.contentLicence.html else params.contentLicence.text }}
+          </span>
+        {% else %}
           {% include "./_ogl.svg" %}
           <span class="govuk-footer__licence-description">
             All content is available under the <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated
           </span>
-        {% elif params.licence %}
-          <span class="govuk-footer__licence-description">
-            {{ params.licence | markdown("inline") | replace("govuk-link", "govuk-footer__link") }}
-          </span>
         {% endif %}
       </div>
       <div class="govuk-footer__meta-item">
-      {% if params.copyright == "crown" %}
-        <a class="govuk-footer__link govuk-footer__copyright-logo" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">©&nbsp;Crown copyright</a>
-      {% elif params.copyright %}
-        {{ params.copyright | markdown("inline") | replace("govuk-link", "govuk-footer__link") }}
+      {%- if params.copyright.html or params.copyright.text -%}
+        {{ params.copyright.html | safe if params.copyright.html else params.copyright.text }}
       {% else %}
-        ©&nbsp;{{ "now" | date("yyyy") }}
+        <a class="govuk-footer__link govuk-footer__copyright-logo" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">©&nbsp;Crown copyright</a>
       {% endif %}
       </div>
     </div>

--- a/docs/options.md
+++ b/docs/options.md
@@ -71,7 +71,11 @@ Options for site search. See [adding a site search](../search).
 
 In addition to the [options available for the footer component](https://design-system.service.gov.uk/components/footer/), the following options can also be set:
 
-| Name | Type | Description | Default |
-| :--- | :--- | :---------- | :------ |
-| **copyright** | string | Copyright statement. Can contain inline Markdown. If set to `'crown'`, `© Crown copyright` is displayed below an image of the Royal Coat of Arms. If set to `false`, the current year is shown (i.e. `© {{ "now" | date("yyyy") }}`). | `'crown'` |
-| **licence** | string | Licence description. Can contain inline Markdown. If set to `'ogl'`, the OGL logo is shown alongside the words `All content is available under the Open Government Licence v3.0, except where otherwise stated`. | `'ogl'` |
+| Name | Type | Description |
+| :--- | :--- | :---------- |
+| **contentLicence** | object | Licence description. If no value is provided, the OGL logo is shown alongside the words `All content is available under the Open Government Licence v3.0, except where otherwise stated`. |
+| **contentLicence.text** | string | If `html` is set, this is not required. If `html` is provided, the `text` option will be ignored. |
+| **contentLicence.html** | string | If `text` is set, this is not required. If `html` is provided, the `text` option will be ignored. |
+| **copyright** | object | Copyright statement. If no value is provided, `© Crown copyright` is displayed below an image of the Royal Coat of Arms. |
+| **copyright.text** | string | If `html` is set, this is not required. If `html` is provided, the `text` option will be ignored. |
+| **copyright.html** | string | If `text` is set, this is not required. If `html` is provided, the `text` option will be ignored. |


### PR DESCRIPTION
`govuk-frontend` v4.3.0 [provides some customisation for the content licence and copyright statement shown in the footer component](https://github.com/alphagov/govuk-frontend/pull/2702).

Unfortunately this isn’t as extensive as that provided by the plugin, namely in that the Royal Coat of Arms and OGL logo remain even if the content changes. That means we still need a fork of this component. However, we can align the options so that the configuration options for the plugin behave the same as that for the component in the Design System. When new configuration options are provides to enable the footer images to be changed, this plugin should be able to then remove the bespoke component, and authors can then use those additional options.