### PR TITLE
Increase specificity of heading anchors, rename as modifier of `govuk-link`

### DIFF
--- a/components/all.scss
+++ b/components/all.scss
@@ -5,6 +5,6 @@
 @import "document-list/document-list";
 @import "footnotes-list/footnotes-list";
 @import "header/header";
-@import "heading-anchor/heading-anchor";
+@import "link/link";
 @import "prose-scope/prose-scope";
 @import "site-search/site-search";

--- a/components/link/_link.scss
+++ b/components/link/_link.scss
@@ -1,5 +1,4 @@
-.app-heading-anchor {
-  @include govuk-link-common;
+.govuk-link.app-link--heading {
   @include govuk-link-style-text;
   @include govuk-link-style-no-underline;
 

--- a/lib/markdown-it.js
+++ b/lib/markdown-it.js
@@ -27,7 +27,7 @@ module.exports = (options = {}) => {
     .use(anchor, {
       permalink: options.headingPermalinks
         ? anchor.permalink.headerLink({
-          class: 'app-heading-anchor',
+          class: 'app-link--heading',
           safariReaderFix: true
         })
         : false


### PR DESCRIPTION
https://github.com/x-govuk/markdown-it-govuk/commit/f30e7c37e8512b203ebbd48ad71371a0335a15a2 fixed an issue where heading anchors had 2 separate `class` attributes, one for the heading anchor class, the other the injected `govuk-link` class. This was flagged as a warning by the HTML validator.

Fixing this issue however, means that `govuk-link` now gets applied to heading anchor links as intended, resulting in a specificity issue, and heading anchors appearing as normal links.

This PR:

* Increases the specificity of the heading anchor class
* Renames it to follow the naming conventions used when extending a class provided by `govuk-frontend` (from `app-heading-anchor` to `app-link--heading`).