### PR TITLE
Fix for #96 - Use local copy of nunjucks dependencies if present

### DIFF
--- a/lib/nunjucks.js
+++ b/lib/nunjucks.js
@@ -1,5 +1,19 @@
 const path = require('node:path')
 const Nunjucks = require('nunjucks')
+const fs = require('node:fs')
+
+/**
+ * If there is a version conflict between a govuk-eleventy-plugin dependency
+ * and the host project's dependencies, npm will include the expected version
+ * in a nested node_modules folder.
+ *
+ * @param {string} module
+ * @return {string}
+ */
+const resolveNpmModule = (module) => {
+  const localPath = `./node_modules/govuk-eleventy-plugin/node_modules/${module}`
+  return fs.existsSync(localPath) ? localPath : `./node_modules/${module}`
+}
 
 /**
  * Configure Nunjucks environment
@@ -18,8 +32,8 @@ module.exports = (eleventyConfig) => {
 
   const searchPaths = [
     './node_modules/govuk-eleventy-plugin',
-    './node_modules/govuk-frontend',
-    './node_modules/govuk-prototype-components',
+    resolveNpmModule('govuk-frontend'),
+    resolveNpmModule('govuk-prototype-components'),
     ...(includes ? [path.join(input, includes)] : []),
     ...(layouts ? [path.join(input, layouts)] : []),
     ...input


### PR DESCRIPTION
If there is a version conflict between a govuk-eleventy-plugin dependency and the host project's dependencies, npm will include the expected version in a nested node_modules folder.

This adds a check for `govuk-frontend` and `govuk-prototype-components` existing in a nested node_modules folder, uses that path if it exists, otherwise defaults to the version in the root node_modules folder.

Fixes issue #96.