### PR TITLE
Allow asset, fonts and image path SCSS options to be set

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -25,47 +25,50 @@ module.exports = function(eleventyConfig) {
 
 ## Plugin options
 
-| Name | Type | Description | Default |
-| :--- | :--- | :---------- | :------ |
-| **brandColour** | string | Override the default value for `$govuk-brand-colour`. Must be a hex value (i.e. `#1d70b8`). | `false` |
-| **fontFamily** | string | Override the default value for `$govuk-font-family`. Must be a list of one or more font family names (i.e. `"GDS Transport", arial, sans-serif`). | `false` |
-| **icons.mask** | string | Override the default GOV.UK SVG mask icon. | `false` |
-| **icons.shortcut** | string | Override the default GOV.UK favicon. | `false` |
-| **icons.touch** | string | Override the default GOV.UK touch icon. | `false` |
-| **opengraphImageUrl** | string | URL for default Open Graph share image. | `false` |
-| **themeColour** | string | Browser theme colour. Must be a hex value. | `#0b0c0c` |
-| **headingPermalinks** | boolean | Add links to headings, making it easier to share sections of a page. | `false` |
-| **homeKey** | string | Label to use for first item in pagination and key to use when referring to the home page for [`eleventyNavigation.parent`](https://www.11ty.dev/docs/plugins/navigation/). | `'Home'` |
-| **parentSite** | object | Website to show as first item in breadcrumbs. | `false` |
-| **parentSite.url** | string | URL for parent site. | |
-| **parentSite.name** | string | Name of parent site. | |
-| **pathPrefix** | string | If your site lives in a different subdirectory (particularly useful with GitHub pages), use `pathPrefix` to specify this. It's used by the `url` filter and inserted at the beginning of all absolute URLs. Used in conjunction with [Eleventy’s own `pathPrefix` option](https://www.11ty.dev/docs/config/#deploy-to-a-subdirectory-with-a-path-prefix). | `'/'`
-| **stylesheets** | Array | Additional stylesheets to load after application styles. | `[]` |
-| **url** | string | The URL of your website. Optional, but required to have valid canonical URLs in Open Graph meta data. | `false` |
-| **header** | object | See [header](#options-for-header). | |
-| **footer** | object | See [footer](#options-for-footer). | |
+| Name | Type | Description |
+| :--- | :--- | :---------- |
+| **brandColour** | string | Override default value for `$govuk-brand-colour`. Must be a hex value (i.e. `#1d70b8`). |
+| **fontFamily** | string | Override default value for `$govuk-font-family`. Must be a list of one or more font family names (i.e. `"GDS Transport", arial, sans-serif`).
+| **assetsPath** | string | Override default value for `$govuk-assets-path`. |
+| **fontsPath** | string | Override default value for `$govuk-fonts-path`. |
+| **imagesPath** | string | Override default value for `$govuk-images-path`. |
+| **icons.mask** | string | Override default GOV.UK SVG mask icon. |
+| **icons.shortcut** | string | Override default GOV.UK favicon. |
+| **icons.touch** | string | Override default GOV.UK touch icon. |
+| **opengraphImageUrl** | string | URL for default Open Graph share image. |
+| **themeColour** | string | Browser theme colour. Must be a hex value, i.e. `#0b0c0c` |
+| **headingPermalinks** | boolean | Add links to headings, making it easier to share sections of a page. |
+| **homeKey** | string | Label to use for first item in pagination and key to use when referring to the home page for [`eleventyNavigation.parent`](https://www.11ty.dev/docs/plugins/navigation/). Default is `'Home'` |
+| **parentSite** | object | Website to show as first item in breadcrumbs. |
+| **parentSite.url** | string | URL for parent site. |
+| **parentSite.name** | string | Name of parent site. |
+| **pathPrefix** | string | If your site lives in a different subdirectory (particularly useful with GitHub pages), use `pathPrefix` to specify this. It's used by the `url` filter and inserted at the beginning of all absolute URLs. Used in conjunction with [Eleventy’s own `pathPrefix` option](https://www.11ty.dev/docs/config/#deploy-to-a-subdirectory-with-a-path-prefix). |
+| **stylesheets** | Array | Additional stylesheets to load after application styles. |
+| **url** | string | The URL of your website. Optional, but required to have valid canonical URLs in Open Graph meta data. |
+| **header** | object | See [header](#options-for-header). |
+| **footer** | object | See [footer](#options-for-footer). |
 
 ### Options for header
 
 In addition to the [options available for the header component](https://design-system.service.gov.uk/components/header/), the following options can also be set:
 
-| Name | Type | Description | Default |
-| :--- | :--- | :---------- | :------ |
-| **homepageUrl** | string | URL organisation name is linked to. | `'/'` |
-| **organisationLogo** | string | Logo that appears before the organisation name. If set to `crown` the GOV.UK logo is shown. If set to `royal-arms`, the Royal Coat of Arms is shown. | `'crown'` |
-| **organisationName** | string | Organisation name. | `'GOV.UK'` |
-| **productName** | string | Product name that appears after the organisation name. Default is `false`. | `false` |
-| **search** | object | See [header.search](#options-for-header.search). | `false` |
+| Name | Type | Description |
+| :--- | :--- | :---------- |
+| **homepageUrl** | string | URL organisation name is linked to. Default is `'/'` |
+| **organisationLogo** | string | Logo that appears before the organisation name. If set to `crown` the GOV.UK logo is shown. If set to `royal-arms`, the Royal Coat of Arms is shown. Default is `'crown'` |
+| **organisationName** | string | Organisation name. Default is `'GOV.UK'` |
+| **productName** | string | Product name that appears after the organisation name. Default is `false`. |
+| **search** | object | See [header.search](#options-for-header.search). |
 
 ### Options for header.search
 
 Options for site search. See [adding a site search](../search).
 
-| Name | Type | Description | Default |
-| :--- | :--- | :---------- | :------ |
-| **label** | string | Text to show in the search field. | `'Search site'` |
-| **indexPath** | string | Path to search index file. If set, a search input will be shown in the header. | `false` |
-| **sitemapPath** | string | Path to sitemap page. | `false` |
+| Name | Type | Description |
+| :--- | :--- | :---------- |
+| **label** | string | Text to show in the search field. Default is `'Search site'` |
+| **indexPath** | string | Path to search index file. If set, a search input will be shown in the header. |
+| **sitemapPath** | string | Path to sitemap page. |
 
 ### Options for footer
 

--- a/lib/events/generate-govuk-assets.js
+++ b/lib/events/generate-govuk-assets.js
@@ -16,16 +16,17 @@ module.exports = async function (eleventyConfig, options) {
   // eleventyConfig does not provide the default value for dir.output
   // https://github.com/11ty/eleventy/blob/36713b3af81b08530fac532ceef24f5dde8acb36/src/defaultConfig.js#L64
   const outputDir = eleventyConfig.dir.output || '_site'
-
-  const govukBrandColour = options.brandColour ? options.brandColour : ''
-  const govukFontFamily = options.fontFamily ? options.fontFamily : ''
+  const { assetsPath, imagesPath, fontsPath, brandColour, fontFamily } = options
 
   // Get plugin options and set GOV.UK Frontend variables if provided
   const inputFilePath = path.join(__dirname, '../govuk.scss')
   const inputFile = await fs.readFile(inputFilePath)
   const source = [
-    govukBrandColour ? `$govuk-brand-colour: ${govukBrandColour};` : [],
-    govukFontFamily ? `$govuk-font-family: ${govukFontFamily};` : [],
+    assetsPath ? `$govuk-assets-path: "${assetsPath}";` : [],
+    fontsPath ? `$govuk-fonts-path: "${fontsPath}";` : [],
+    imagesPath ? `$govuk-images-path: "${imagesPath}";` : [],
+    brandColour ? `$govuk-brand-colour: ${brandColour};` : [],
+    fontFamily ? `$govuk-font-family: ${fontFamily};` : [],
     inputFile
   ].join('\n')
 


### PR DESCRIPTION
GOV.UK Frontend provides a number of SCSS values that can be configured. So far we allow users to change:

* `$govuk-brand-colour`
* `$govuk-font-family`

There are also additional [options that allow different paths to static assets to be set](https://frontend.design-system.service.gov.uk/importing-css-assets-and-javascript/#copy-the-font-and-image-files-into-your-application):

* `$govuk-assets-path`
* `$govuk-fonts-path`
* `$govuk-images-path`

From the perspective of only altering a site’s theme, I didn’t think these would need to be set. However, configuring the asset path was requested in #60 and subsequently in that thread, it was pointed out that fonts (and images) won’t load if a site is hosted on sub-folder (which is common for GitHub Pages).

This PR:

1. Adds three new options: `assetsPath`, `fontsPath` and `imagesPath`
2. Updates the documentation with these three new options, and also simplifies the description of each option, only showing default values where applicable.

Once this PR is merged and new version released, sites using this plug-in can be hosted on GitHub pages. A separate PR will be created adding documentation on this options that need to be changed (and workflow you can use) to host an Eleventy site using GitHub Pages. 