### PR TITLE
Tags

### DIFF
--- a/components/document-header/template.njk
+++ b/components/document-header/template.njk
@@ -18,26 +18,32 @@
 
   {% if params.date or params.modified or params.authors or params.author %}
     <p class="app-document-header__metadata">
-      {% if params.authors %}
-        <span class="govuk-visually-hidden">Posted by: </span>
+      {%- if params.authors -%}
+        <span class="govuk-visually-hidden">Posted by</span>
         {%- for author in params.authors -%}
           {{- " and " if loop.last else (", " if not loop.first) -}}
           {{- _authorLink(author) -}}
         {%- endfor -%}
-        <span aria-hidden="true"> · </span>
-      {% elif params.author %}
-          {{- _authorLink(params.author) -}}
-          <span aria-hidden="true"> · </span>
-      {% endif %}
-      {% if params.date %}
-        <span class="govuk-visually-hidden">Posted on: </span><time datetime="{{ params.date | date }}">{{ params.date | date("d LLLL y") }}</time>
-      {% endif %}
-      {% if params.modified %}
-        <span aria-hidden="true">•</span>
-        Last updated <time datetime="{{ params.modified | date }}">{{ params.modified | date("d LLLL y") }}</time>
-      {% endif %}
+        <span aria-hidden="true">&ensp;•&ensp;</span>
+      {%- elif params.author -%}
+        {{- _authorLink(params.author) -}}
+        <span aria-hidden="true">&ensp;•&ensp;</span>
+      {%- endif -%}
+      {%- if params.date -%}
+        <span class="govuk-visually-hidden">Posted on </span><time datetime="{{ params.date | date }}">{{ params.date | date("d LLLL y") }}</time>
+      {%- endif -%}
+      {%- if params.modified -%}
+        <span aria-hidden="true">&ensp;•&ensp;</span>Last updated <time datetime="{{ params.modified | date }}">{{ params.modified | date("d LLLL y") }}</time>
+      {%- endif -%}
+      {%- if params.tags | length > 0 -%}
+        <span aria-hidden="true">&ensp;•&ensp;</span>Tags:
+        {%- for tag in params.tags %}
+          {% set item = params.tagPages | includes("data.tag", tag) | first %}
+          <a href="{{ item.url }}" class="govuk-link">{{ item.data.tag }}</a>
+          {%- if not loop.last %}, {% endif %}
+        {%- endfor -%}
+      {%- endif -%}
     </p>
   {% endif %}
-
 </header>
 

--- a/components/document-list/_document-list.scss
+++ b/components/document-list/_document-list.scss
@@ -30,7 +30,10 @@
   color: $govuk-secondary-text-colour;
   display: inline-block;
   margin: 0;
-  padding-right: govuk-spacing(4);
+
+  & + .app-document-list__attribute:before {
+    content: "\2002•\2002";
+  }
 }
 
 .app-document-list--large {

--- a/components/document-list/template.njk
+++ b/components/document-list/template.njk
@@ -12,11 +12,18 @@
         {{ item.data.description | markdown("inline") | safe }}
       </p>
       {% endif %}
-      {% if item.data.date %}
+      {% if item.data.date or item.data.tags %}
       <ul class="app-document-list__item-metadata">
+        {% if item.data.date %}
         <li class="app-document-list__attribute">
           <time datetime="{{ item.data.date | date }}">{{ item.data.date | date("d LLLL y") }}</time>
         </li>
+        {% endif %}
+        {% if item.data.tags %}
+        <li class="app-document-list__attribute">
+          Tags: {{ item.data.tags | join(", ") }}
+        </li>
+        {% endif %}
       </ul>
       {% endif %}
     </li>

--- a/docs/hosting.md
+++ b/docs/hosting.md
@@ -1,6 +1,6 @@
 ---
 layout: sub-navigation
-order: 7
+order: 8
 title: Hosting
 description: Hosting Eleventy websites on services like GitHub Pages.
 ---

--- a/docs/layouts/post.md
+++ b/docs/layouts/post.md
@@ -3,7 +3,8 @@ layout: post
 order: 3
 title: Post
 description: Layout for date-based content, such as blog posts or news items.
-date: 2011-11-11
+date: 2011-12-21
+modified: 2012-12-22
 image:
   src: /assets/images/govuk-opengraph-image.png
   alt: A crown icon above the words GOV.UK.
@@ -30,6 +31,8 @@ related:
           items:
           - text: Front matter data
             href: https://www.11ty.dev/docs/data-frontmatter/
+tags:
+  - example tag
 ---
 Use front matter options to customise the appearance, content and behaviour of this layout.
 
@@ -40,7 +43,8 @@ layout: post
 order: 3
 title: Post
 description: Layout for date-based content, such as blog posts or news items.
-date: 2011-11-11
+date: 2011-12-21
+modified: 2012-12-22
 image:
   src: /assets/images/govuk-opengraph-image.png
   alt: A crown icon above the words GOV.UK.
@@ -67,6 +71,8 @@ related:
           items:
           - text: Front matter data
             href: https://www.11ty.dev/docs/data-frontmatter/
+tags:
+  - example tag
 ```
 
 {% from "govuk/components/details/macro.njk" import govukDetails %}
@@ -92,3 +98,5 @@ In addition to the common front matter options, this layout also accepts the fol
 | **image.alt** | string | Alternative text for post image. |
 | **image.caption** | string | Caption shown below post image. |
 | **image.opengraphImage** | boolean | Whether image should also be used as the page’s Open Graph share image. |
+| **modified** | string | Date post was updated. Use [ISO 8601 format](https://en.wikipedia.org/wiki/ISO_8601), for example `{{ "now" | date("yyyy-MM-dd") }}`. |
+| **tags** | Array | List of tags post relates to |

--- a/docs/tag.md
+++ b/docs/tag.md
@@ -1,0 +1,13 @@
+---
+layout: tag
+pagination:
+  addAllPagesToCollections: true
+  alias: tag
+  data: collections.tags
+  size: 1
+permalink: "/tags/{{ tag | slug }}/"
+eleventyComputed:
+  title: "Pages tagged ‘{{ tag }}’"
+eleventyNavigation:
+  parent: "Tags"
+---

--- a/docs/tagging.md
+++ b/docs/tagging.md
@@ -1,0 +1,43 @@
+---
+layout: sub-navigation
+order: 7
+title: Adding tags
+description: Use tags to categorise posts and make it easier for readers to browse content on your site.
+---
+
+The GOV.UK Eleventy Plugin lets you use tags to categorise pages. Each post can display its list of tags, which link to a page that lists other posts with the same tag. Follow these instructions to enable this feature.
+
+## Create a page that lists all tags used
+
+To include a list of all tags used on your website, create a page that uses the `tags` layout:
+
+```yaml
+---
+layout: tags
+title: Tags
+---
+```
+
+You can see an [example of a tag index](../tags) on this website.
+
+## Create a page for each tag
+
+To generate a page for each tag used on your website, create a page that uses the `tag` layout and paginates `collections.tags` data:
+
+```yaml
+---
+layout: tag
+pagination:
+  addAllPagesToCollections: true
+  alias: tag
+  data: collections.tags
+  size: 1
+permalink: "/tags/{% raw %}{{ tag | slug }}{% endraw %}/"
+eleventyComputed:
+  title: "Posts tagged ‘{{ tag }}’"
+eleventyNavigation:
+  parent: Tags
+---
+```
+
+You can see an [example tag page](../tags/example-tag) on this website.

--- a/docs/tags.md
+++ b/docs/tags.md
@@ -1,0 +1,4 @@
+---
+layout: tags
+title: Tags
+---

--- a/index.js
+++ b/index.js
@@ -8,6 +8,8 @@ module.exports = function (eleventyConfig, pluginOptions = {}) {
   // Collections
   eleventyConfig.addCollection('ordered', require('./lib/collections/ordered.js'))
   eleventyConfig.addCollection('sitemap', require('./lib/collections/sitemap.js'))
+  eleventyConfig.addCollection('tags', require('./lib/collections/tags.js'))
+  eleventyConfig.addCollection('tagPages', require('./lib/collections/tag-pages.js'))
 
   // Extensions and template formats
   eleventyConfig.addExtension('scss', require('./lib/extensions/scss.js'))
@@ -15,6 +17,7 @@ module.exports = function (eleventyConfig, pluginOptions = {}) {
 
   // Filters
   eleventyConfig.addFilter('date', require('./lib/filters/date.js'))
+  eleventyConfig.addFilter('includes', require('./lib/filters/includes.js'))
   eleventyConfig.addFilter('itemsFromCollection', require('./lib/filters/items-from-collection.js'))
   eleventyConfig.addFilter('itemsFromPagination', require('./lib/filters/items-from-pagination.js'))
   eleventyConfig.addFilter('itemsFromNavigation', require('./lib/filters/items-from-navigation.js'))

--- a/layouts/post.njk
+++ b/layouts/post.njk
@@ -15,7 +15,9 @@
         date: date,
         modified: modified,
         author: author,
-        authors: authors
+        authors: authors,
+        tags: tags,
+        tagPages: collections.tagPages
       }) }}
     </div>
 

--- a/layouts/tag.njk
+++ b/layouts/tag.njk
@@ -1,0 +1,24 @@
+{% extends "layouts/base.njk" %}
+
+{% block beforeContent %}
+  {{ govukBreadcrumbs({
+    classes: "govuk-!-display-none-print",
+    items: breadcrumbItems
+  }) if showBreadcrumbs }}
+{% endblock %}
+
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    {{ appDocumentHeader({
+      title: title or ("Posts tagged ‘" + tag + "’")
+    }) }}
+
+    {{ appDocumentList({
+      headingLevel: 3 if paginationHeading else 2,
+      classes: "app-document-list--large",
+      items: collections[tag] | reverse
+    }) }}
+  </div>
+</div>
+{% endblock %}

--- a/layouts/tags.njk
+++ b/layouts/tags.njk
@@ -1,0 +1,27 @@
+{% extends "layouts/base.njk" %}
+
+{% block beforeContent %}
+  {{ govukBreadcrumbs({
+    classes: "govuk-!-display-none-print",
+    items: breadcrumbItems
+  }) if showBreadcrumbs }}
+{% endblock %}
+
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    {{ appDocumentHeader({
+      title: title or "Tags"
+    }) }}
+
+    <ul class="govuk-list govuk-list--bullet">
+      {% for item in collections.tagPages %}
+      <li>
+        <a href="{{ item.url }}">{{ item.data.tag }}</a>
+        ({{ collections[item.data.tag] | length }})
+      </li>
+      {% endfor %}
+    </ul>
+  </div>
+</div>
+{% endblock %}

--- a/lib/collections/ordered.js
+++ b/lib/collections/ordered.js
@@ -1,11 +1,12 @@
-module.exports = (collection) => {
-  return collection.getAll().sort((a, b) => {
-    if (typeof a.data.order !== 'undefined' && typeof b.data.order !== 'undefined') { // Sort by order value, if given
-      return (a.data.order || 0) - (b.data.order || 0)
-    } else { // Sort by title
-      if (a.data.title < b.data.title) return -1
-      else if (a.data.title > b.data.title) return 1
-      else return 0
-    }
-  })
-}
+module.exports = (collection) =>
+  collection.getAll()
+    .filter((item) => !/^tag/.test(item.data.layout))
+    .sort((a, b) => {
+      if (typeof a.data.order !== 'undefined' && typeof b.data.order !== 'undefined') { // Sort by order value, if given
+        return (a.data.order || 0) - (b.data.order || 0)
+      } else { // Sort by title
+        if (a.data.title < b.data.title) return -1
+        else if (a.data.title > b.data.title) return 1
+        else return 0
+      }
+    })

--- a/lib/collections/tag-pages.js
+++ b/lib/collections/tag-pages.js
@@ -1,0 +1,2 @@
+module.exports = (collection) =>
+  collection.getAllSorted().filter((item) => item.data.layout === 'tag')

--- a/lib/collections/tags.js
+++ b/lib/collections/tags.js
@@ -1,0 +1,28 @@
+module.exports = (collection) => {
+  const items = collection.getAll()
+  let tags = []
+
+  for (const item of items) {
+    if ('tags' in item.data) {
+      // Add any new tags from the post to the array
+      for (const tag of item.data.tags) {
+        // Skip if tag already added
+        if (tags.includes(tag)) { continue }
+
+        // Check there’s not a matching tag, except for capitalisation
+        const existingTag = tags.find(existingTag => existingTag.toLowerCase() === tag.toLowerCase())
+        if (existingTag) {
+          throw new Error(`The post ‘${item.data.title}’ contains tag ‘${tag}’ which matches ‘${existingTag}’, but the capitalisation is different.`)
+        }
+
+        // Otherwise add new tag
+        tags.push(tag)
+      }
+    }
+  }
+
+  // Sort tags alphabetically
+  tags = tags.sort((a, b) => a.localeCompare(b, 'en'))
+
+  return tags
+}

--- a/lib/filters/includes.js
+++ b/lib/filters/includes.js
@@ -1,0 +1,21 @@
+/**
+ * Select objects in array whose key includes a value
+ *
+ * @param {Array} array Array to filter
+ * @param {string} keyPath Key to inspect
+ * @param {string} value Value key needs to include
+ * @returns {Array} Filtered array
+ */
+module.exports = (array, keyPath, value) => array.filter(item => {
+  let data = item
+  for (const key of keyPath.split('.')) {
+    data = data[key]
+  }
+
+  // If data doesn’t exist, abort
+  if (!data) {
+    return false
+  }
+
+  return (data.includes(value) ? item : false)
+})


### PR DESCRIPTION
Fixes #113.

Adding tags involves adding a tags page using the `tags` layout, and a tag page that uses the `tag` layout and paginates `collections.tags` data. Tags are shown in the header of posts, and in document listings. 

![Screenshot of post page with tags in header meta](https://user-images.githubusercontent.com/813383/212332696-7f3dd340-0d60-468c-8c0b-05d7d3317739.png)

![Tags page](https://user-images.githubusercontent.com/813383/212332706-49b421b7-36da-48c6-b5e6-281ce9c63038.png)

![Tag page](https://user-images.githubusercontent.com/813383/212332703-2f4f44c0-ca1f-454a-8122-523e655793d6.png)
