### PR TITLE
Ensure custom asset paths end with a slash

### DIFF
--- a/lib/events/generate-govuk-assets.js
+++ b/lib/events/generate-govuk-assets.js
@@ -4,6 +4,7 @@ const sass = require('sass')
 const rollup = require('rollup')
 const commonJs = require('@rollup/plugin-commonjs')
 const { nodeResolve } = require('@rollup/plugin-node-resolve')
+const { ensureSlash } = require('../utils.js')
 
 /**
  * Generate GOV.UK Frontend assets
@@ -22,9 +23,9 @@ module.exports = async function (eleventyConfig, options) {
   const inputFilePath = path.join(__dirname, '../govuk.scss')
   const inputFile = await fs.readFile(inputFilePath)
   const source = [
-    assetsPath ? `$govuk-assets-path: "${assetsPath}";` : [],
-    fontsPath ? `$govuk-fonts-path: "${fontsPath}";` : [],
-    imagesPath ? `$govuk-images-path: "${imagesPath}";` : [],
+    assetsPath ? `$govuk-assets-path: "${ensureSlash(assetsPath)}";` : [],
+    fontsPath ? `$govuk-fonts-path: "${ensureSlash(fontsPath)}";` : [],
+    imagesPath ? `$govuk-images-path: "${ensureSlash(imagesPath)}";` : [],
     brandColour ? `$govuk-brand-colour: ${brandColour};` : [],
     fontFamily ? `$govuk-font-family: ${fontFamily};` : [],
     inputFile

--- a/lib/filters/markdown.js
+++ b/lib/filters/markdown.js
@@ -1,5 +1,5 @@
 const md = require('../markdown-it.js')()
-const normalise = require('../utils.js')
+const { normalise } = require('../utils.js')
 
 /**
  * Convert Markdown into GOV.UK Frontend-compliant HTML

--- a/lib/filters/no-orphans.js
+++ b/lib/filters/no-orphans.js
@@ -1,4 +1,4 @@
-const normalise = require('../utils.js')
+const { normalise } = require('../utils.js')
 
 /**
  * Insert non-breaking space between the last two words of a string. This

--- a/lib/filters/smart.js
+++ b/lib/filters/smart.js
@@ -1,4 +1,4 @@
-const normalise = require('../utils.js')
+const { normalise } = require('../utils.js')
 const smartypants = require('smartypants')
 
 /**

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,22 @@
 /**
+  * Ensure string ends with a slash
+  *
+  * @param {string} string - String
+  * @return {string} String ending with a `/`
+  */
+const ensureSlash = (string) => {
+  if (typeof string !== 'string') {
+    throw new TypeError('Input must be a string')
+  }
+
+  if (string.charAt(string.length - 1) === '/') {
+    return string
+  }
+
+  return `${string}/`
+}
+
+/**
  * Normalise value provided to a filter. Checks that a given value exists
  * before performing a transformation.
  *
@@ -15,5 +33,6 @@ const normalise = (value, defaultValue) => {
 }
 
 module.exports = {
+  ensureSlash,
   normalise
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,10 +6,14 @@
  * @param {*} defaultValue - Value to fallback to if no value given
  * @returns defaultValue
  */
-module.exports = (value, defaultValue) => {
+const normalise = (value, defaultValue) => {
   if (value === null || value === undefined || value === false) {
     return defaultValue
   }
 
   return value
+}
+
+module.exports = {
+  normalise
 }

--- a/tests/lib/utils.mjs
+++ b/tests/lib/utils.mjs
@@ -1,9 +1,9 @@
 import test from 'ava'
-import utils from '../../lib/utils.js'
+import { normalise } from '../../lib/utils.js'
 
 test('Normalises value provided to a filter', t => {
-  const usesValue = utils('Dollars', 'Pounds')
-  const usesDefault = utils(undefined, 'Pounds')
+  const usesValue = normalise('Dollars', 'Pounds')
+  const usesDefault = normalise(undefined, 'Pounds')
 
   t.is(usesValue, 'Dollars')
   t.is(usesDefault, 'Pounds')

--- a/tests/lib/utils.mjs
+++ b/tests/lib/utils.mjs
@@ -1,5 +1,10 @@
 import test from 'ava'
-import { normalise } from '../../lib/utils.js'
+import { ensureSlash, normalise } from '../../lib/utils.js'
+
+test('Ensures string ends with a slash', t => {
+  t.is(ensureSlash('path'), 'path/')
+  t.is(ensureSlash('path/'), 'path/')
+})
 
 test('Normalises value provided to a filter', t => {
   const usesValue = normalise('Dollars', 'Pounds')


### PR DESCRIPTION
Asset paths provided to SCSS variables in `govuk-frontend` need to end with a slash, for later concatenation with asset paths.

This PR adds a method to ensure that any path used for `assetsPath`, `imagesPath` and `fontsPath` ends with a slash.