### PR TITLE
Include Twitter image meta tag

### DIFF
--- a/layouts/base.njk
+++ b/layouts/base.njk
@@ -49,7 +49,11 @@
   <meta property="og:title" content="{{ title }}">
   {% if description %}<meta property="og:description" name="description" content="{{ description | markdown("inline") | striptags(true) }}">{% endif %}
   {% if opengraphImage %}<meta name="twitter:card" content="summary_large_image">{% endif %}
-  {% if opengraphImage.src %}<meta property="og:image" content="{{ opengraphImage.src | url | absoluteUrl(options.url) }}">{% endif %}
+  {% if opengraphImage.src %}
+    <meta property="og:image" content="{{ opengraphImage.src | url | absoluteUrl(options.url) }}">
+    <meta name="twitter:image" content="{{ opengraphImage.src | url | absoluteUrl(options.url) }}">
+  {% endif %}
+  
   {% if opengraphImage.alt %}<meta property="og:image:alt" content="{{ opengraphImage.alt }}">{% endif %}
 {% endblock %}
 


### PR DESCRIPTION
Twitter doesn’t seem to parse the openGraph meta tag (any more?) so might need to duplicate the tags... 😞