### PR TITLE
Include Twitter image meta tag (redux)

### DIFF
--- a/docs/layouts/post.md
+++ b/docs/layouts/post.md
@@ -9,6 +9,7 @@ image:
   src: /assets/images/govuk-opengraph-image.png
   alt: A crown icon above the words GOV.UK.
   caption: The GOV.UK logo
+  opengraphImage: true
 authors:
   - name: William Ewart Gladstone
     url: https://www.gov.uk/government/history/past-prime-ministers/william-ewart-gladstone

--- a/layouts/base.njk
+++ b/layouts/base.njk
@@ -49,11 +49,7 @@
   <meta property="og:title" content="{{ title }}">
   {% if description %}<meta property="og:description" name="description" content="{{ description | markdown("inline") | striptags(true) }}">{% endif %}
   {% if opengraphImage %}<meta name="twitter:card" content="summary_large_image">{% endif %}
-  {% if opengraphImage.src %}
-    <meta property="og:image" content="{{ opengraphImage.src | url | absoluteUrl(options.url) }}">
-    <meta name="twitter:image" content="{{ opengraphImage.src | url | absoluteUrl(options.url) }}">
-  {% endif %}
-  
+  {% if opengraphImage.src %}<meta property="og:image" name="twitter:image" content="{{ opengraphImage.src | url | absoluteUrl(options.url) }}">{% endif %}
   {% if opengraphImage.alt %}<meta property="og:image:alt" content="{{ opengraphImage.alt }}">{% endif %}
 {% endblock %}
 


### PR DESCRIPTION
Follows on from #137.

I’m pretty sure you can have both `property="og:image"` and `name="twitter:image"` in the same `meta` tag, at least that’s how I’ve done it previously. Updating the template to revert to previous markup, but with the inclusion of `name="twitter:image"`, which saves the image URL being declared twice.

Also, added `opengraphImage: true` to the post layout; that’s what you need to do if you want to explicitly opt-in a post image to be the open graph share image (which in the case of this layout example is actually the same image).

Will merge this PR so I can test on Twitter. If it works I’ll release an update, and then update the posts on X-GOV.UK site so that the post images get opted in.