### PR TITLE
Display dates in search layout correctly

### DIFF
--- a/layouts/search-index.njk
+++ b/layouts/search-index.njk
@@ -4,8 +4,8 @@
     {% if item.data.description %}"description": {{ item.data.description | dump | safe }},{% endif %}
     {% if item.data.eleventyNavigation.parent %}"section": {{ item.data.eleventyNavigation.parent | dump | safe }},{% endif %}
     "layout": {{ item.data.layout | dump | safe }},
-    {% if item.data.date %}"date": {{ item.data.date | date | dump | safe }},
-    "dateString": {{ item.data.date  | date("d LLLL y") | dump | safe }},{% endif %}
+    {% if item.data.page.date %}"date": {{ item.data.page.date | date | dump | safe }},
+    "dateString": {{ item.data.page.date  | date("d LLLL y") | dump | safe }},{% endif %}
     "templateContent": {{ item.templateContent | tokenize | dump | safe }},
     "url": {{ item.url | url | pretty | dump | safe }}
   }{% if not loop.last %},{% endif %}


### PR DESCRIPTION
Fixes #154  issue with search layout not displaying page date content. For instances where commands such as 'git Last Modified' was passed into date, the search index would render null or invalid.
Instead now use the rendered date from the page object instead.