### PR TITLE
Refactor search index metadata display

### DIFF
--- a/components/site-search/site-search.js
+++ b/components/site-search/site-search.js
@@ -84,10 +84,15 @@ Search.prototype.resultTemplate = function (result) {
     const resultTitle = result.title
     element.textContent = resultTitle
 
-    if (result.dateString || result.section) {
+    if (result.hasFrontmatterDate || result.section) {
       const section = document.createElement('span')
       section.className = 'app-site-search--section'
-      section.innerHTML = result.dateString || result.section
+
+      if (result.hasFrontmatterDate && result.section) {
+        section.innerHTML = `${result.section}<br>${result.date}`
+      } else {
+        section.innerHTML = result.section || result.date
+      }
 
       element.appendChild(section)
     }

--- a/layouts/search-index.njk
+++ b/layouts/search-index.njk
@@ -4,8 +4,8 @@
     {% if item.data.description %}"description": {{ item.data.description | dump | safe }},{% endif %}
     {% if item.data.eleventyNavigation.parent %}"section": {{ item.data.eleventyNavigation.parent | dump | safe }},{% endif %}
     "layout": {{ item.data.layout | dump | safe }},
-    {% if item.data.page.date %}"date": {{ item.data.page.date | date | dump | safe }},
-    "dateString": {{ item.data.page.date  | date("d LLLL y") | dump | safe }},{% endif %}
+    "hasFrontmatterDate": {{ item.data.date !== undefined }},
+    "date": {{ item.date | date("d LLLL y") | dump | safe }},
     "templateContent": {{ item.templateContent | tokenize | dump | safe }},
     "url": {{ item.url | url | pretty | dump | safe }}
   }{% if not loop.last %},{% endif %}


### PR DESCRIPTION
Returning to #154, which identified an issue with non ISO 8601 dates being given in front matter data and returning `Invalid DateTime`, and following on from the fix provided in #155. Turns out, it’s a little bit more complicated.

* All pages in an Eleventy site have a date; this can be given in a page’s frontmatter, else it is derived from its file name or its last modified date.
* Frontmatter dates can be IS08601, or keyword based (i.e. `git Last Modified`). Eleventy will convert any given valid frontmatter date into a JavaScript date and use that for `page.date` (i.e. we can always rely on `page.date` being a valid datetime).
* We don’t want to show a date for a search result item if a date was not given in its frontmatter.

So, for a given search result item:

* Add a flag to the search index template to indicate if a frontmatter date has been provided. If this is `true`, and the page also belongs to a section, show both the date and section name
* Else, if a page belongs to a section, show the section name
* Else, if a page has a frontmatter date, show the date
* Else, only show the page title

It’s enough to make your head spin! Basically, this change enables the potential for search result items to be displayed thus:

* **Page title**
* **Page title**
  Section name
* **Post title**
  19 May 2023
* **Post title**
  Section name
  19 May 2023

/cc @robertdeniszczyc2 