### PR TITLE
Fix large logotype alignment in header

### DIFF
--- a/components/header/_header.scss
+++ b/components/header/_header.scss
@@ -15,15 +15,10 @@
   }
 
   // Height of crown is 30px.
-  // Accept slightly larger icons with a height of 35px
+  // Visually adjust placement to accept larger icons with a height of 35px
   .app-header__logotype--large {
-    // Visually adjust placement
-    margin: -3px 0 -8px;
-
-    .govuk-header__link--homepage:not(:focus):hover & {
-      // Prevent underline interfering with larger logo, whose height means
-      // it falls below the baseline
-      background-color: govuk-colour("black");
-    }
+    margin-bottom: -10px;
+    position: relative;
+    top: -3px;
   }
 }


### PR DESCRIPTION
Fixes #158.

Turns out this is only an issue when using the `'system-ui, sans-serif'` font stack as San Francisco (at least) has slightly different font metrics fringe GDS Transport, and browsers being browsers…

I’ve adjusted the implementation so that the logo appears 1px higher up than before, and removed the horrible hack to prevent the underline appearing below or behind the larger logo, making this consistent with the standard logo size behaviour.

| Before | After |
| - | - |
| <img width="380" alt="Before" src="https://github.com/x-govuk/govuk-eleventy-plugin/assets/813383/390657e3-56d6-4ca1-b04d-7333a452f73e"> | <img width="370" alt="After" src="https://github.com/x-govuk/govuk-eleventy-plugin/assets/813383/f41f0224-e6b9-4b9c-8ae7-307640a2d0f7"> |

Have tested this change using the `royal-arms` icon and GDS Transport font, and this remains largely unaffected, if not improved as the Royal Coat of Arms is now one pixel away from underline. Proof:

<img width="165" alt="Screenshot 2023-05-21 at 22 27 52" src="https://github.com/x-govuk/govuk-eleventy-plugin/assets/813383/3164deba-3c32-48f0-a4b9-e170c519ce6d">

(Fun fact; this is no longer the correct coat of arms as it shows St Edward's Crown, not the Tudor Crown 🤓)