### PR TITLE
Display dates on tag page correctly

### DIFF
--- a/components/document-list/template.njk
+++ b/components/document-list/template.njk
@@ -12,11 +12,11 @@
         {{ item.data.description | markdown("inline") | safe }}
       </p>
       {% endif %}
-      {% if item.data.date or item.data.tags %}
+      {% if item.data.page.date or item.data.tags %}
       <ul class="app-document-list__item-metadata">
-        {% if item.data.date %}
+        {% if item.data.page.date %}
         <li class="app-document-list__attribute">
-          <time datetime="{{ item.data.date | date }}">{{ item.data.date | date("d LLLL y") }}</time>
+          <time datetime="{{ item.data.page.date | date }}">{{ item.data.page.date | date("d LLLL y") }}</time>
         </li>
         {% endif %}
         {% if item.data.tags %}

--- a/docs/tagging.md
+++ b/docs/tagging.md
@@ -15,6 +15,7 @@ To include a list of all tags used on your website, create a page that uses the 
 ---
 layout: tags
 title: Tags
+permalink: "/tags/"
 ---
 ```
 
@@ -34,7 +35,7 @@ pagination:
   size: 1
 permalink: "/tags/{% raw %}{{ tag | slug }}{% endraw %}/"
 eleventyComputed:
-  title: "Posts tagged ‘{{ tag }}’"
+  title: "Posts tagged ‘{% raw %}{{ tag }}{% endraw %}’"
 eleventyNavigation:
   parent: Tags
 ---


### PR DESCRIPTION
- Fixes issue with dates not appearing in tab page (page listing all pages using a specific tag) 
- Updated documentation for tag page, title code now displays `{{tag}}` correctly