### PR TITLE
Use template inheritance to include masthead component `beforeContent`

### DIFF
--- a/layouts/collection.njk
+++ b/layouts/collection.njk
@@ -1,4 +1,4 @@
-{% extends "layouts/product.njk" %}
+{% extends "layouts/base.njk" %}
 
 {% block main %}
   {{ xGovukMasthead({
@@ -14,44 +14,41 @@
     } if showBreadcrumbs
   }) }}
 
-  <div class="govuk-width-container">
-    {% block beforeContent %}{% endblock %}
-    <main class="govuk-main-wrapper {{ mainClasses }}" id="main-content" role="main"{% if mainLang %} lang="{{ mainLang }}"{% endif %}>
-    {% block content %}
-      <div class="govuk-grid-row">
-        <section class="govuk-grid-column-two-thirds-from-desktop">
-          {{ appProseScope(content) if content }}
+  {{ super() }}
+{% endblock %}
 
-          {% if paginationHeading %}
-            <h2 class="govuk-heading-l govuk-!-font-size-27">
-              {{ paginationHeading }}
-            </h2>
-          {% endif %}
+{% block content %}
+<div class="govuk-grid-row">
+  <section class="govuk-grid-column-two-thirds-from-desktop">
+    {{ appProseScope(content) if content }}
 
-          {{ appDocumentList({
-            headingLevel: 3 if paginationHeading else 2,
-            classes: "app-document-list--large",
-            items: pagination.items
-          }) }}
+    {% if paginationHeading %}
+      <h2 class="govuk-heading-l govuk-!-font-size-27">
+        {{ paginationHeading }}
+      </h2>
+    {% endif %}
 
-          {{ govukPagination({
-            previous: {
-              href: pagination.href.previous
-            },
-            next: {
-              href: pagination.href.next
-            },
-            items: pagination | itemsFromPagination
-          }) if pagination.pages.length > 1 }}
-        </section>
+    {{ appDocumentList({
+      headingLevel: 3 if paginationHeading else 2,
+      classes: "app-document-list--large",
+      items: pagination.items
+    }) }}
 
-        {% if aside or related %}
-          <div class="govuk-grid-column-one-third-from-desktop">
-            {% include "layouts/shared/related.njk" %}
-          </div>
-        {% endif %}
-      </div>
-    {% endblock %}
-    </main>
+    {{ govukPagination({
+      previous: {
+        href: pagination.href.previous
+      },
+      next: {
+        href: pagination.href.next
+      },
+      items: pagination | itemsFromPagination
+    }) if pagination.pages.length > 1 }}
+  </section>
+
+  {% if aside or related %}
+  <div class="govuk-grid-column-one-third-from-desktop">
+    {% include "layouts/shared/related.njk" %}
   </div>
+  {% endif %}
+</div>
 {% endblock %}

--- a/layouts/product.njk
+++ b/layouts/product.njk
@@ -23,14 +23,11 @@
     } if showBreadcrumbs
   }) }}
 
-  <div class="govuk-width-container">
-    {% block beforeContent %}{% endblock %}
-    <main class="govuk-main-wrapper {{ mainClasses }}" id="main-content" role="main"{% if mainLang %} lang="{{ mainLang }}"{% endif %}>
-      {% block content %}
-        {{ appProseScope(content) if content }}
+  {{ super() }}
+{% endblock %}
 
-        {% include "layouts/shared/related.njk" %}
-      {% endblock %}
-    </main>
-  </div>
+{% block content %}
+  {{ appProseScope(content) if content }}
+
+  {% include "layouts/shared/related.njk" %}
 {% endblock %}


### PR DESCRIPTION
Result of investigating #169. Turns out this refactor keeps the generated markup as it is currently, but uses template inheritance to insert the masthead in the `main` block using `super()`, rather than rewriting part of the `govuk-frontend` template.