### PR TITLE
Update linting to use Stylelint v15 and Prettier

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,10 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: 'github-actions'
+    directory: '/'
     schedule:
-      interval: "monthly"
-  - package-ecosystem: "npm"
-    directory: "/"
+      interval: 'monthly'
+  - package-ecosystem: 'npm'
+    directory: '/'
     schedule:
-      interval: "monthly"
+      interval: 'monthly'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,16 +23,16 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-    - name: Setup Pages
-      uses: actions/configure-pages@v3
-    - name: Install dependencies
-      run: npm ci
-    - name: Build with Eleventy
-      run: npm run-script build
-    - name: Upload artifact
-      uses: actions/upload-pages-artifact@v1
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+      - name: Install dependencies
+        run: npm ci
+      - name: Build with Eleventy
+        run: npm run-script build
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
 
   deploy:
     environment:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: "${{ steps.nvm.outputs.NVMRC }}"
+          node-version: '${{ steps.nvm.outputs.NVMRC }}'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+# JavaScript (formatted with Standard)
+**/*.js
+**/*.mjs

--- a/README.md
+++ b/README.md
@@ -4,16 +4,16 @@ Build documentation websites using Markdown and GOV.UK styles.
 
 You’re welcome to use the plugin even if your service isn’t considered part of GOV.UK, but your site or service must not:
 
-* identify itself as being part of GOV.UK
-* use the crown or GOV.UK logotype in the header
-* use the GDS Transport typeface
-* suggest that it’s an official UK government website if it’s not
+- identify itself as being part of GOV.UK
+- use the crown or GOV.UK logotype in the header
+- use the GDS Transport typeface
+- suggest that it’s an official UK government website if it’s not
 
 ## Requirements
 
-* [Node.js](https://nodejs.org) v16.0.0 or above
-* [npm CLI](https://docs.npmjs.com/cli) v8.0.0 or above
-* [Eleventy](https://www.11ty.dev) v2.0.0 or above
+- [Node.js](https://nodejs.org) v16.0.0 or above
+- [npm CLI](https://docs.npmjs.com/cli) v8.0.0 or above
+- [Eleventy](https://www.11ty.dev) v2.0.0 or above
 
 ## Installation
 

--- a/components/contents-list/_contents-list.scss
+++ b/components/contents-list/_contents-list.scss
@@ -28,7 +28,7 @@
     padding-left: govuk-spacing(5);
     position: relative;
 
-    &:before {
+    &::before {
       content: "—";
       left: 0;
       overflow: hidden;

--- a/components/document-list/_document-list.scss
+++ b/components/document-list/_document-list.scss
@@ -31,7 +31,7 @@
   display: inline-block;
   margin: 0;
 
-  & + .app-document-list__attribute:before {
+  & + .app-document-list__attribute::before {
     content: "\2002•\2002";
   }
 }

--- a/components/footnotes-list/_footnotes-list.scss
+++ b/components/footnotes-list/_footnotes-list.scss
@@ -4,12 +4,12 @@ a[aria-describedby="footnotes-label"] {
   @include govuk-link-style-no-visited-state;
 }
 
-a[aria-describedby="footnotes-label"]:before {
+a[aria-describedby="footnotes-label"]::before {
   color: currentcolor;
   content: "[";
 }
 
-a[aria-describedby="footnotes-label"]:after {
+a[aria-describedby="footnotes-label"]::after {
   color: currentcolor;
   content: "]";
 }
@@ -26,7 +26,7 @@ a[aria-describedby="footnotes-label"]:after {
     position: relative;
   }
 
-  li:before {
+  li::before {
     @include govuk-font(19, $tabular: true);
     content: counter(footnotes) ".";
     position: absolute;

--- a/components/link/_link.scss
+++ b/components/link/_link.scss
@@ -13,7 +13,7 @@
     font-variant: all-small-caps;
     font-weight: normal;
     margin-left: govuk-spacing(1);
-    opacity: .5;
+    opacity: 0.5;
   }
 }
 

--- a/components/link/_link.scss
+++ b/components/link/_link.scss
@@ -6,8 +6,8 @@
     text-decoration: none;
   }
 
-  &:hover:after,
-  :target &:after {
+  &:hover::after,
+  :target &::after {
     color: govuk-colour("dark-grey");
     content: "#";
     font-variant: all-small-caps;

--- a/components/prose-scope/_prose-scope.scss
+++ b/components/prose-scope/_prose-scope.scss
@@ -34,11 +34,11 @@
   }
 
   sup {
-    top: -.4em;
+    top: -0.4em;
   }
 
   sub {
-    bottom: -.4em;
+    bottom: -0.4em;
   }
 
   img {
@@ -56,7 +56,7 @@
     // Show outline around linked images within figures
     img {
       display: block;
-      outline: 1px solid rgba($govuk-border-colour, .5);
+      outline: 1px solid rgba($govuk-border-colour, 0.5);
     }
 
     > .govuk-link img {

--- a/components/site-search/_site-search.scss
+++ b/components/site-search/_site-search.scss
@@ -115,7 +115,7 @@ $icon-size: 40px;
 }
 
 .app-site-search__menu--overlay {
-  box-shadow: rgba(govuk-colour("black"), .25) 0 2px 6px;
+  box-shadow: rgba(govuk-colour("black"), 0.25) 0 2px 6px;
   left: 0;
   position: absolute;
   top: 100%;

--- a/components/site-search/_site-search.scss
+++ b/components/site-search/_site-search.scss
@@ -190,11 +190,11 @@ $icon-size: 40px;
 .app-site-search__aliases {
   margin-left: govuk-spacing(1);
 
-  &:before {
+  &::before {
     content: "(";
   }
 
-  &:after {
+  &::after {
     content: ")";
   }
 }

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -9,23 +9,23 @@ You can use this plugin to create and publish documentation and other simple web
 
 This plugin includes the following features:
 
-* a set of [layouts](../layouts) that use [`govuk-frontend`](https://github.com/alphagov/govuk-frontend) components and styles
+- a set of [layouts](../layouts) that use [`govuk-frontend`](https://github.com/alphagov/govuk-frontend) components and styles
 
-* includes [`markdown-it-govuk`](https://github.com/x-govuk/markdown-it-govuk) to ensure pages uses the same typography and styles as those used on GOV.UK
+- includes [`markdown-it-govuk`](https://github.com/x-govuk/markdown-it-govuk) to ensure pages uses the same typography and styles as those used on GOV.UK
 
-* support for an [extended Markdown syntax](../markdown-advanced)
+- support for an [extended Markdown syntax](../markdown-advanced)
 
-* [full configuration](../options) of your website’s header and footer
+- [full configuration](../options) of your website’s header and footer
 
-* site search
+- site search
 
-* SCSS compilation (for any files with the `.scss` extension)
+- SCSS compilation (for any files with the `.scss` extension)
 
 ## Requirements
 
-* [Node.js](https://nodejs.org/en/) v16.0.0 or above
-* [npm CLI](https://docs.npmjs.com/cli) v8.0.0 or above
-* [Eleventy](https://www.11ty.dev) v2.0.0 or above
+- [Node.js](https://nodejs.org/en/) v16.0.0 or above
+- [npm CLI](https://docs.npmjs.com/cli) v8.0.0 or above
+- [Eleventy](https://www.11ty.dev) v2.0.0 or above
 
 [Node version manager](https://github.com/nvm-sh/nvm) is recommended if you are working across multiple projects that use different versions of Node.js.
 
@@ -97,11 +97,11 @@ The first page in your site should also have a `homepage` value set to `true`[^1
 
 [^1]: Using `homepage: true` is equivalent to writing the following:
 
-      ```yaml
-      eleventyComputed:
-        eleventyNavigation:
-          key: "{% raw %}{{ config.homeKey }}{% endraw %}"
-      ```
+    ```yaml
+    eleventyComputed:
+      eleventyNavigation:
+        key: "{% raw %}{{ config.homeKey }}{% endraw %}"
+    ```
 
 Open the preview URL in your browser to see this new page appear using GOV.UK styles.
 
@@ -111,6 +111,6 @@ This plugin provides {{ collections["layout"] | length }} different layouts, eac
 
 {% for page in collections["layout"] %}
 
-* [{{ page.data.title }}]({{ page.url | url }}) – {{ page.data.description }}
+- [{{ page.data.title }}]({{ page.url | url }}) – {{ page.data.description }}
 
 {% endfor %}

--- a/docs/includes/front-matter-options.md
+++ b/docs/includes/front-matter-options.md
@@ -1,41 +1,41 @@
 Use these options to customise the appearance, content and behaviour of any layout.
 
-| Name | Type | Description |
-| :--- | :--- | :---------- |
-| **layout** | string | Page layout. |
-| **includeInBreadcrumbs** | boolean | Include page as the last item in any breadcrumbs. Default is `false`. |
-| **order** | number | Ranking of page in navigation. Lower numbers appear before pages with a higher number. |
-| **title** | string | Page title. |
-| **description** | string | Page description. |
-| **opengraphImage** | object | Open Graph image that appears on social media networks. |
-| **opengraphImage.src** | string | Path to Open Graph image. Can be a relative or absolute URL. This value overrides `opengraphImageUrl` in plugin options. |
-| **opengraphImage.alt** | string | Alternative text for Open Graph image. |
-| **aside** | object | Small portion of content that is indirectly related to the main content. |
-| **aside.title** | string | Title for aside. |
-| **aside.content** | string | Content for aside. Accepts Markdown. |
-| **related** | object | Related links. See [related](#options-for-related). |
+| Name                     | Type    | Description                                                                                                              |
+| :----------------------- | :------ | :----------------------------------------------------------------------------------------------------------------------- |
+| **layout**               | string  | Page layout.                                                                                                             |
+| **includeInBreadcrumbs** | boolean | Include page as the last item in any breadcrumbs. Default is `false`.                                                    |
+| **order**                | number  | Ranking of page in navigation. Lower numbers appear before pages with a higher number.                                   |
+| **title**                | string  | Page title.                                                                                                              |
+| **description**          | string  | Page description.                                                                                                        |
+| **opengraphImage**       | object  | Open Graph image that appears on social media networks.                                                                  |
+| **opengraphImage.src**   | string  | Path to Open Graph image. Can be a relative or absolute URL. This value overrides `opengraphImageUrl` in plugin options. |
+| **opengraphImage.alt**   | string  | Alternative text for Open Graph image.                                                                                   |
+| **aside**                | object  | Small portion of content that is indirectly related to the main content.                                                 |
+| **aside.title**          | string  | Title for aside.                                                                                                         |
+| **aside.content**        | string  | Content for aside. Accepts Markdown.                                                                                     |
+| **related**              | object  | Related links. See [related](#options-for-related).                                                                      |
 
 ### Options for related
 
 With one section:
 
-| Name | Type | Description |
-| :--- | :--- | :---------- |
-| **title** | string | Title for group of related links. Default is `'Related content'`. |
-| **items** | array | See [items](#options-for-items). |
-| **subsections** | array | Title for sub-group of related links. |
-| **subsections.title** | string | |
-| **subsections.items** | array | See [items](#options-for-items). |
+| Name                  | Type   | Description                                                       |
+| :-------------------- | :----- | :---------------------------------------------------------------- |
+| **title**             | string | Title for group of related links. Default is `'Related content'`. |
+| **items**             | array  | See [items](#options-for-items).                                  |
+| **subsections**       | array  | Title for sub-group of related links.                             |
+| **subsections.title** | string |                                                                   |
+| **subsections.items** | array  | See [items](#options-for-items).                                  |
 
 With multiple sections:
 
-| Name | Type | Description |
-| :--- | :--- | :---------- |
+| Name         | Type  | Description                        |
+| :----------- | :---- | :--------------------------------- |
 | **sections** | array | See [items](#options-for-related). |
 
 ### Options for items
 
-| Name | Type | Description |
-| :--- | :--- | :---------- |
-| **text** | string | Title of related content. |
+| Name     | Type   | Description                   |
+| :------- | :----- | :---------------------------- |
+| **text** | string | Title of related content.     |
 | **href** | string | Link for the related content. |

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,7 @@ startButton:
 eleventyComputed:
   title: "{{ pkg.description }}"
 ---
+
 <div class="govuk-grid-row">
 {% for item in collections["homepage"] %}
   <section class="govuk-grid-column-one-third-from-desktop govuk-!-margin-bottom-8">

--- a/docs/layouts.md
+++ b/docs/layouts.md
@@ -6,9 +6,10 @@ description: The plugin offers a number of layouts to match the type of content 
 tags:
   - homepage
 ---
+
 {% for page in collections["layout"] %}
 
-* [{{ page.data.title }}]({{ page.url | url }}) – {{ page.data.description }}
+- [{{ page.data.title }}]({{ page.url | url }}) – {{ page.data.description }}
 
 {% endfor %}
 
@@ -33,7 +34,7 @@ module.exports = function(eleventyConfig) {
 };
 ```
 
-If you want to use your own layouts, remove this value and set a value for [`dir.includes`](https://www.11ty.dev/docs/config/#directory-for-includes) (and optionally [`dir.layouts`](https://www.11ty.dev/docs/config/#directory-for-layouts-(optional))).
+If you want to use your own layouts, remove this value and set a value for [`dir.includes`](https://www.11ty.dev/docs/config/#directory-for-includes) (and optionally [`dir.layouts`](<https://www.11ty.dev/docs/config/#directory-for-layouts-(optional)>)).
 
 You can use layouts provided by this plugin as a basis for your own. For example, to show a notification banner at the top of a page, extend the `page` layout:
 
@@ -47,7 +48,7 @@ You can use layouts provided by this plugin as a basis for your own. For example
 {% block content %}
   {# Templates can include front matter data #}
   {{ govukNotificationBanner({
-    text: "This page was last reviewed on " + (reviewed | date("d LLLL y")) + ".  
+    text: "This page was last reviewed on " + (reviewed | date("d LLLL y")) + ".
     It needs to be reviewed again on " + (reviewAgain | date("d LLLL y")) + "."
   }) if reviewed and reviewAgain }}
 

--- a/docs/layouts/collection.md
+++ b/docs/layouts/collection.md
@@ -46,6 +46,7 @@ related:
           - text: Front matter data
             href: https://www.11ty.dev/docs/data-frontmatter/
 ---
+
 Use front matter options to customise the appearance, content and behaviour of this layout.
 
 For example, this page has the following options:
@@ -82,7 +83,7 @@ example:
       description: What we learnt from our first round of user research.
 aside:
   title: Aside
-  content: | 
+  content: |
     A small portion of content that is **indirectly** related to the main content.
 related:
   sections:
@@ -108,7 +109,7 @@ related:
 
 In addition to the common front matter options, this layout also accepts the following options:
 
-| Name | Type | Description |
-| :--- | :--- | :---------- |
-| **paginationHeading** | string | Heading for the list of paginated pages. |
-| **pagination** | object | **Required.** Pages to show in the paginated list. Learn more about [pagination](https://www.11ty.dev/docs/pagination/) in the documentation for Eleventy. |
+| Name                  | Type   | Description                                                                                                                                                |
+| :-------------------- | :----- | :--------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **paginationHeading** | string | Heading for the list of paginated pages.                                                                                                                   |
+| **pagination**        | object | **Required.** Pages to show in the paginated list. Learn more about [pagination](https://www.11ty.dev/docs/pagination/) in the documentation for Eleventy. |

--- a/docs/layouts/page.md
+++ b/docs/layouts/page.md
@@ -21,6 +21,7 @@ related:
           - text: Front matter data
             href: https://www.11ty.dev/docs/data-frontmatter/
 ---
+
 Use front matter options to customise the appearance, content and behaviour of this layout.
 
 For example, this page has the following options:
@@ -32,7 +33,7 @@ title: Page
 description: Simple layout designed for maximum flexibility of content.
 aside:
   title: Aside
-  content: | 
+  content: |
     A small portion of content that is **indirectly** related to the main content.
 related:
   sections:

--- a/docs/layouts/post.md
+++ b/docs/layouts/post.md
@@ -35,6 +35,7 @@ related:
 tags:
   - example tag
 ---
+
 Use front matter options to customise the appearance, content and behaviour of this layout.
 
 For example, this page has the following options:
@@ -57,7 +58,7 @@ authors:
     url: https://www.gov.uk/government/history/past-prime-ministers/benjamin-disraeli-the-earl-of-beaconsfield
 aside:
   title: Aside
-  content: | 
+  content: |
     A small portion of content that is **indirectly** related to the main content.
 related:
   sections:
@@ -85,19 +86,19 @@ tags:
 
 In addition to the common front matter options, this layout also accepts the following options:
 
-| Name | Type | Description |
-| :--- | :--- | :---------- |
-| **author** | string&nbsp;or&nbsp;object | Post author. |
-| **author.name** | string | Name of post author. Overrides any single value given for author. |
-| **author.url** | string | URL for website of post author. |
-| **authors** | array | Post authors. Overrides any value(s) given for author. |
-| **authors.name** | string | Name of post author. |
-| **authors.url** | string | URL for website of post author. |
-| **date** | string | Date post was published. Use [ISO 8601 format](https://en.wikipedia.org/wiki/ISO_8601), for example `{{ "now" | date("yyyy-MM-dd") }}`. |
-| **image** | object | Image shown above post content. |
-| **image.src** | string | Path to post image. |
-| **image.alt** | string | Alternative text for post image. |
-| **image.caption** | string | Caption shown below post image. |
-| **image.opengraphImage** | boolean | Whether image should also be used as the page’s Open Graph share image. |
-| **modified** | string | Date post was updated. Use [ISO 8601 format](https://en.wikipedia.org/wiki/ISO_8601), for example `{{ "now" | date("yyyy-MM-dd") }}`. |
-| **tags** | Array | List of tags post relates to |
+| Name                     | Type                       | Description                                                                                                   |
+| :----------------------- | :------------------------- | :------------------------------------------------------------------------------------------------------------ | ----------------------- |
+| **author**               | string&nbsp;or&nbsp;object | Post author.                                                                                                  |
+| **author.name**          | string                     | Name of post author. Overrides any single value given for author.                                             |
+| **author.url**           | string                     | URL for website of post author.                                                                               |
+| **authors**              | array                      | Post authors. Overrides any value(s) given for author.                                                        |
+| **authors.name**         | string                     | Name of post author.                                                                                          |
+| **authors.url**          | string                     | URL for website of post author.                                                                               |
+| **date**                 | string                     | Date post was published. Use [ISO 8601 format](https://en.wikipedia.org/wiki/ISO_8601), for example `{{ "now" | date("yyyy-MM-dd") }}`. |
+| **image**                | object                     | Image shown above post content.                                                                               |
+| **image.src**            | string                     | Path to post image.                                                                                           |
+| **image.alt**            | string                     | Alternative text for post image.                                                                              |
+| **image.caption**        | string                     | Caption shown below post image.                                                                               |
+| **image.opengraphImage** | boolean                    | Whether image should also be used as the page’s Open Graph share image.                                       |
+| **modified**             | string                     | Date post was updated. Use [ISO 8601 format](https://en.wikipedia.org/wiki/ISO_8601), for example `{{ "now"   | date("yyyy-MM-dd") }}`. |
+| **tags**                 | Array                      | List of tags post relates to                                                                                  |

--- a/docs/layouts/product.md
+++ b/docs/layouts/product.md
@@ -27,6 +27,7 @@ related:
           - text: Front matter data
             href: https://www.11ty.dev/docs/data-frontmatter/
 ---
+
 Use front matter options to customise the appearance, content and behaviour of this layout.
 
 For example, this page has the following options:
@@ -44,7 +45,7 @@ image:
   alt: Eleventy’s possum mascot hanging on a red balloon and floating above a laptop.
 aside:
   title: Aside
-  content: | 
+  content: |
     A small portion of content that is **indirectly** related to the main content.
 related:
   sections:
@@ -72,11 +73,11 @@ related:
 
 In addition to the common front matter options, this layout also has the following options:
 
-| Name | Type | Description |
-| :--- | :--- | :---------- |
-| **startButton** | string | Start button. Appears below the title and any description. |
-| **startButton.text** | string | Text for the start button. Default is `'Get started'`. |
-| **startButton.href** | string | The URL that the start button should link to. |
-| **image** | object | Product image. Appears to the right of the page title, and is hidden on mobile. |
-| **image.src** | string | Path to product image. |
-| **image.alt** | string | Alternative text for product image. |
+| Name                 | Type   | Description                                                                     |
+| :------------------- | :----- | :------------------------------------------------------------------------------ |
+| **startButton**      | string | Start button. Appears below the title and any description.                      |
+| **startButton.text** | string | Text for the start button. Default is `'Get started'`.                          |
+| **startButton.href** | string | The URL that the start button should link to.                                   |
+| **image**            | object | Product image. Appears to the right of the page title, and is hidden on mobile. |
+| **image.src**        | string | Path to product image.                                                          |
+| **image.alt**        | string | Alternative text for product image.                                             |

--- a/docs/layouts/sub-navigation.md
+++ b/docs/layouts/sub-navigation.md
@@ -21,6 +21,7 @@ related:
           - text: Front matter data
             href: https://www.11ty.dev/docs/data-frontmatter/
 ---
+
 The `sub-navigation` layout offers a page with sub navigation, appearing to the left of content on wider viewports, and above on narrower ones.
 
 Use front matter options to customise the appearance, content and behaviour of this layout.
@@ -34,7 +35,7 @@ title: Page with sub navigation
 description: Layout with sub navigation.
 aside:
   title: Aside
-  content: | 
+  content: |
     A small portion of content that is **indirectly** related to the main content.
 related:
   sections:

--- a/docs/markdown-advanced.md
+++ b/docs/markdown-advanced.md
@@ -9,6 +9,7 @@ related:
       - text: Markdown Guide
         href: https://www.markdownguide.org
 ---
+
 [[toc]]
 
 ## Tables
@@ -51,16 +52,16 @@ You can align text in the columns to the left, right, or center by adding a colo
 
 The rendered output looks like this:
 
-| Syntax    | Description | Test Text   |
+| Syntax    | Description |   Test Text |
 | :-------- | :---------: | ----------: |
-| Header    | Title       | Here's this |
-| Paragraph | Text        | And more    |
+| Header    |    Title    | Here's this |
+| Paragraph |    Text     |    And more |
 
 ## Fenced code
 
 The basic Markdown syntax allows you to create [code blocks](../markdown#code-blocks) by indenting lines by 4 spaces or one tab. If you find that inconvenient, try using fenced code blocks. You can use 3 backticks (` ``` `) or 3 tildes (`~~~`) on the lines before and after the code block.
 
-~~~markdown
+````markdown
 ```
 {
   "firstName": "William",
@@ -68,7 +69,7 @@ The basic Markdown syntax allows you to create [code blocks](../markdown#code-bl
   "age": 24
 }
 ```
-~~~
+````
 
 The rendered output looks like this:
 
@@ -84,7 +85,7 @@ The rendered output looks like this:
 
 This feature allows you to add color highlighting for whatever language your code was written in. To add syntax highlighting, specify a language next to the backticks before the fenced code block.
 
-~~~markdown
+````markdown
 ```json
 {
   "firstName": "William",
@@ -92,7 +93,7 @@ This feature allows you to add color highlighting for whatever language your cod
   "age": 24
 }
 ```
-~~~
+````
 
 The rendered output looks like this:
 
@@ -137,7 +138,6 @@ The rendered output looks like this:
 Here's a simple footnote,[^1] and here's a longer one.[^bignote]
 
 [^1]: This is the first footnote.
-
 [^bignote]: Here's one with multiple paragraphs and code.
 
     Indent paragraphs to include them in the footnote.
@@ -162,11 +162,11 @@ This policy is the responsibility of the DWP.
 
 This policy is the responsibility of the DWP.
 
-*[DWP]: Department for Work and Pensions
+\*[DWP]: Department for Work and Pensions
 
 ## Definition lists
 
-To create a definition list, type the term on the first line. On the next line, type a colon followed by a space and the definition.  
+To create a definition list, type the term on the first line. On the next line, type a colon followed by a space and the definition.
 
 ```markdown
 First Term

--- a/docs/markdown.md
+++ b/docs/markdown.md
@@ -247,7 +247,7 @@ Visit [GOV.UK](https://www.gov.uk).
 To quickly turn a URL or email address into a link, enclose it in angle brackets.
 
 ```markdown
-<https://www.gov.uk>  
+<https://www.gov.uk>
 <mailbox@example.org>
 ```
 
@@ -261,7 +261,7 @@ The rendered output looks like this:
 To [emphasize](../markdown#emphasis) links, add asterisks before and after the brackets and parentheses. To denote links as [code](../markdown#code), add backticks in the brackets.
 
 ```markdown
-Visit the **[Markdown Guide](https://www.markdownguide.org)**.  
+Visit the **[Markdown Guide](https://www.markdownguide.org)**.
 See the section on [`code`](../markdown#code).
 ```
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -9,7 +9,7 @@ tags:
 
 You can add options to the second parameter of the `addPlugin` function in Eleventy config file.
 
-For example, to add a product name  to the right of the GOV.UK text in the header, you would add the following:
+For example, to add a product name to the right of the GOV.UK text in the header, you would add the following:
 
 ```js
 const govukEleventyPlugin = require('@x-govuk/govuk-eleventy-plugin')
@@ -25,59 +25,59 @@ module.exports = function(eleventyConfig) {
 
 ## Plugin options
 
-| Name | Type | Description |
-| :--- | :--- | :---------- |
-| **brandColour** | string | Override default value for `$govuk-brand-colour`. Must be a hex value (i.e. `#1d70b8`). |
-| **fontFamily** | string | Override default value for `$govuk-font-family`. Must be a list of one or more font family names (i.e. `"GDS Transport", arial, sans-serif`).
-| **assetsPath** | string | Override default value for `$govuk-assets-path`. |
-| **fontsPath** | string | Override default value for `$govuk-fonts-path`. |
-| **imagesPath** | string | Override default value for `$govuk-images-path`. |
-| **icons.mask** | string | Override default GOV.UK SVG mask icon. |
-| **icons.shortcut** | string | Override default GOV.UK favicon. |
-| **icons.touch** | string | Override default GOV.UK touch icon. |
-| **opengraphImageUrl** | string | URL for default Open Graph share image. |
-| **themeColour** | string | Browser theme colour. Must be a hex value, i.e. `#0b0c0c` |
-| **headingPermalinks** | boolean | Add links to headings, making it easier to share sections of a page. |
-| **homeKey** | string | Label to use for first item in pagination and key to use when referring to the home page for [`eleventyNavigation.parent`](https://www.11ty.dev/docs/plugins/navigation/). Default is `'Home'` |
-| **parentSite** | object | Website to show as first item in breadcrumbs. |
-| **parentSite.url** | string | URL for parent site. |
-| **parentSite.name** | string | Name of parent site. |
-| **stylesheets** | Array | Additional stylesheets to load after application styles. |
-| **url** | string | The URL of your website. Optional, but required to have valid canonical URLs in Open Graph meta data. |
-| **header** | object | See [header](#options-for-header). |
-| **footer** | object | See [footer](#options-for-footer). |
+| Name                  | Type    | Description                                                                                                                                                                                    |
+| :-------------------- | :------ | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **brandColour**       | string  | Override default value for `$govuk-brand-colour`. Must be a hex value (i.e. `#1d70b8`).                                                                                                        |
+| **fontFamily**        | string  | Override default value for `$govuk-font-family`. Must be a list of one or more font family names (i.e. `"GDS Transport", arial, sans-serif`).                                                  |
+| **assetsPath**        | string  | Override default value for `$govuk-assets-path`.                                                                                                                                               |
+| **fontsPath**         | string  | Override default value for `$govuk-fonts-path`.                                                                                                                                                |
+| **imagesPath**        | string  | Override default value for `$govuk-images-path`.                                                                                                                                               |
+| **icons.mask**        | string  | Override default GOV.UK SVG mask icon.                                                                                                                                                         |
+| **icons.shortcut**    | string  | Override default GOV.UK favicon.                                                                                                                                                               |
+| **icons.touch**       | string  | Override default GOV.UK touch icon.                                                                                                                                                            |
+| **opengraphImageUrl** | string  | URL for default Open Graph share image.                                                                                                                                                        |
+| **themeColour**       | string  | Browser theme colour. Must be a hex value, i.e. `#0b0c0c`                                                                                                                                      |
+| **headingPermalinks** | boolean | Add links to headings, making it easier to share sections of a page.                                                                                                                           |
+| **homeKey**           | string  | Label to use for first item in pagination and key to use when referring to the home page for [`eleventyNavigation.parent`](https://www.11ty.dev/docs/plugins/navigation/). Default is `'Home'` |
+| **parentSite**        | object  | Website to show as first item in breadcrumbs.                                                                                                                                                  |
+| **parentSite.url**    | string  | URL for parent site.                                                                                                                                                                           |
+| **parentSite.name**   | string  | Name of parent site.                                                                                                                                                                           |
+| **stylesheets**       | Array   | Additional stylesheets to load after application styles.                                                                                                                                       |
+| **url**               | string  | The URL of your website. Optional, but required to have valid canonical URLs in Open Graph meta data.                                                                                          |
+| **header**            | object  | See [header](#options-for-header).                                                                                                                                                             |
+| **footer**            | object  | See [footer](#options-for-footer).                                                                                                                                                             |
 
 ### Options for header
 
 In addition to the [options available for the header component](https://design-system.service.gov.uk/components/header/), the following options can also be set:
 
-| Name | Type | Description |
-| :--- | :--- | :---------- |
-| **homepageUrl** | string | URL organisation name is linked to. Default is `'/'` |
+| Name                 | Type   | Description                                                                                                                                                               |
+| :------------------- | :----- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **homepageUrl**      | string | URL organisation name is linked to. Default is `'/'`                                                                                                                      |
 | **organisationLogo** | string | Logo that appears before the organisation name. If set to `crown` the GOV.UK logo is shown. If set to `royal-arms`, the Royal Coat of Arms is shown. Default is `'crown'` |
-| **organisationName** | string | Organisation name. Default is `'GOV.UK'` |
-| **productName** | string | Product name that appears after the organisation name. Default is `false`. |
-| **search** | object | See [header.search](#options-for-header.search). |
+| **organisationName** | string | Organisation name. Default is `'GOV.UK'`                                                                                                                                  |
+| **productName**      | string | Product name that appears after the organisation name. Default is `false`.                                                                                                |
+| **search**           | object | See [header.search](#options-for-header.search).                                                                                                                          |
 
 ### Options for header.search
 
 Options for site search. See [adding a site search](../search).
 
-| Name | Type | Description |
-| :--- | :--- | :---------- |
-| **label** | string | Text to show in the search field. Default is `'Search site'` |
-| **indexPath** | string | Path to search index file. If set, a search input will be shown in the header. |
-| **sitemapPath** | string | Path to sitemap page. |
+| Name            | Type   | Description                                                                    |
+| :-------------- | :----- | :----------------------------------------------------------------------------- |
+| **label**       | string | Text to show in the search field. Default is `'Search site'`                   |
+| **indexPath**   | string | Path to search index file. If set, a search input will be shown in the header. |
+| **sitemapPath** | string | Path to sitemap page.                                                          |
 
 ### Options for footer
 
 In addition to the [options available for the footer component](https://design-system.service.gov.uk/components/footer/), the following options can also be set:
 
-| Name | Type | Description |
-| :--- | :--- | :---------- |
-| **contentLicence** | object | Licence description. If no value is provided, the OGL logo is shown alongside the words `All content is available under the Open Government Licence v3.0, except where otherwise stated`. |
-| **contentLicence.text** | string | If `html` is set, this is not required. If `html` is provided, the `text` option will be ignored. |
-| **contentLicence.html** | string | If `text` is set, this is not required. If `html` is provided, the `text` option will be ignored. |
-| **copyright** | object | Copyright statement. If no value is provided, `© Crown copyright` is displayed below an image of the Royal Coat of Arms. |
-| **copyright.text** | string | If `html` is set, this is not required. If `html` is provided, the `text` option will be ignored. |
-| **copyright.html** | string | If `text` is set, this is not required. If `html` is provided, the `text` option will be ignored. |
+| Name                    | Type   | Description                                                                                                                                                                               |
+| :---------------------- | :----- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **contentLicence**      | object | Licence description. If no value is provided, the OGL logo is shown alongside the words `All content is available under the Open Government Licence v3.0, except where otherwise stated`. |
+| **contentLicence.text** | string | If `html` is set, this is not required. If `html` is provided, the `text` option will be ignored.                                                                                         |
+| **contentLicence.html** | string | If `text` is set, this is not required. If `html` is provided, the `text` option will be ignored.                                                                                         |
+| **copyright**           | object | Copyright statement. If no value is provided, `© Crown copyright` is displayed below an image of the Royal Coat of Arms.                                                                 |
+| **copyright.text**      | string | If `html` is set, this is not required. If `html` is provided, the `text` option will be ignored.                                                                                         |
+| **copyright.html**      | string | If `text` is set, this is not required. If `html` is provided, the `text` option will be ignored.                                                                                         |

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "@x-govuk/govuk-eleventy-plugin": "file:./",
         "ava": "^5.1.0",
         "c8": "^8.0.0",
+        "prettier": "^3.0.0",
         "standard": "^17.0.0",
         "stylelint": "^ 15.0.0",
         "stylelint-config-gds": "^1.0.0"
@@ -8274,6 +8275,21 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.0.tgz",
+      "integrity": "sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-ms": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,8 +39,8 @@
         "ava": "^5.1.0",
         "c8": "^8.0.0",
         "standard": "^17.0.0",
-        "stylelint": "^ 14.6.1",
-        "stylelint-config-gds": "^0.3.0"
+        "stylelint": "^ 15.0.0",
+        "stylelint-config-gds": "^1.0.0"
       },
       "engines": {
         "node": "^16.0.0 || ^18.0.0",
@@ -325,20 +325,90 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
-    "node_modules/@csstools/selector-specificity": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-2.2.0.tgz",
-      "integrity": "sha512-+OJ9konv95ClSTOJCmMZqpd5+YGsB2S+x6w3E1oaM8UuR5j8nTNHYSz8c9BEPGDOCMQYIEEGlVPj/VY64iTbGw==",
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-2.3.1.tgz",
+      "integrity": "sha512-xrvsmVUtefWMWQsGgFffqWSK03pZ1vfDki4IVIIUxxDKnGBzqNgv0A7SB1oXtVNEkcVO8xi1ZrTL29HhSu5kGA==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
       "engines": {
         "node": "^14 || ^16 || >=18"
       },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/csstools"
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^2.2.0"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-2.2.0.tgz",
+      "integrity": "sha512-wErmsWCbsmig8sQKkM6pFhr/oPha1bHfvxsUY5CYSQxwyhA9Ulrs8EqCgClhg4Tgg2XapVstGqSVcz0xOYizZA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      }
+    },
+    "node_modules/@csstools/media-query-list-parser": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-2.1.3.tgz",
+      "integrity": "sha512-ATul1u+pic4aVpstgueqxEv4MsObEbszAxfTXpx9LHaeD3LAh+wFqdCteyegWmjk0k5rkSCAvIOaJe9U3DD09w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": "^14 || ^16 || >=18"
       },
       "peerDependencies": {
-        "postcss-selector-parser": "^6.0.10"
+        "@csstools/css-parser-algorithms": "^2.3.1",
+        "@csstools/css-tokenizer": "^2.2.0"
+      }
+    },
+    "node_modules/@csstools/selector-specificity": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-3.0.0.tgz",
+      "integrity": "sha512-hBI9tfBtuPIi885ZsZ32IMEU/5nlZH/KOVYJCOh7gyMxaVLGmLedYqFN6Ui1LXkI8JlC8IsuC0rF0btcRZKd5g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss-selector-parser": "^6.0.13"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -815,12 +885,6 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
-      "dev": true
-    },
-    "node_modules/@types/parse-json": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
     },
     "node_modules/@types/qs": {
@@ -1855,26 +1919,42 @@
       }
     },
     "node_modules/camelcase": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
       "dev": true,
       "engines": {
-        "node": ">=6"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/camelcase-keys": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
-      "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-7.0.2.tgz",
+      "integrity": "sha512-Rjs1H+A9R+Ig+4E/9oyB66UC5Mj9Xq3N//vcLf2WzgdTi/3gUu3Z9KoqmlrEG4VuuLK8wJHofxzdQXz/knhiYg==",
       "dev": true,
       "dependencies": {
-        "camelcase": "^5.3.1",
-        "map-obj": "^4.0.0",
-        "quick-lru": "^4.0.1"
+        "camelcase": "^6.3.0",
+        "map-obj": "^4.1.0",
+        "quick-lru": "^5.1.1",
+        "type-fest": "^1.2.1"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/camelcase-keys/node_modules/type-fest": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -2445,19 +2525,39 @@
       }
     },
     "node_modules/cosmiconfig": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
-      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.2.0.tgz",
+      "integrity": "sha512-3rTMnFJA1tCOPwRxtgF4wd7Ab2qvDbL8jX+3smjIbS4HlZBagTlpERbdN7iAbWlrfxE3M8c27kTwTawQ7st+OQ==",
       "dev": true,
       "dependencies": {
-        "@types/parse-json": "^4.0.0",
         "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
         "parse-json": "^5.0.0",
-        "path-type": "^4.0.0",
-        "yaml": "^1.10.0"
+        "path-type": "^4.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      }
+    },
+    "node_modules/cosmiconfig/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
+    "node_modules/cosmiconfig/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/cross-spawn": {
@@ -2489,6 +2589,19 @@
       "dev": true,
       "engines": {
         "node": ">=12.22"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
+      "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
+      "dev": true,
+      "dependencies": {
+        "mdn-data": "2.0.30",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
       }
     },
     "node_modules/cssesc": {
@@ -2549,12 +2662,15 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-5.0.1.tgz",
+      "integrity": "sha512-VfxadyCECXgQlkoEAjeghAr5gY3Hf+IKjKb+X8tGVDtveCjN+USwprd2q3QXBR9T1+x2DG0XZF5/w+7HAtSaXA==",
       "dev": true,
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/decamelize-keys": {
@@ -2571,6 +2687,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/decamelize-keys/node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/decamelize-keys/node_modules/map-obj": {
@@ -6131,9 +6256,9 @@
       }
     },
     "node_modules/known-css-properties": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.26.0.tgz",
-      "integrity": "sha512-5FZRzrZzNTBruuurWpvZnvP9pum+fe0HcK8z/ooo+U+Hmp4vtbyp1/QDsqmufirXy4egGzbaH/y2uCZf+6W5Kg==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.27.0.tgz",
+      "integrity": "sha512-uMCj6+hZYDoffuvAJjFAPz56E9uoowFHmTkqRtRq5WyC5Q6Cu/fTZKNQpX/RbzChBYLLl3lo8CjFZBAZXq9qFg==",
       "dev": true
     },
     "node_modules/levn": {
@@ -6752,6 +6877,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/mdn-data": {
+      "version": "2.0.30",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
+      "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
+      "dev": true
+    },
     "node_modules/mdurl": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
@@ -6783,35 +6914,35 @@
       }
     },
     "node_modules/meow": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-9.0.0.tgz",
-      "integrity": "sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==",
+      "version": "10.1.5",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-10.1.5.tgz",
+      "integrity": "sha512-/d+PQ4GKmGvM9Bee/DPa8z3mXs/pkvJE2KEThngVNOqtmljC6K7NMPxtc2JeZYTmpWb9k/TmxjeL18ez3h7vCw==",
       "dev": true,
       "dependencies": {
-        "@types/minimist": "^1.2.0",
-        "camelcase-keys": "^6.2.2",
-        "decamelize": "^1.2.0",
+        "@types/minimist": "^1.2.2",
+        "camelcase-keys": "^7.0.0",
+        "decamelize": "^5.0.0",
         "decamelize-keys": "^1.1.0",
         "hard-rejection": "^2.1.0",
         "minimist-options": "4.1.0",
-        "normalize-package-data": "^3.0.0",
-        "read-pkg-up": "^7.0.1",
-        "redent": "^3.0.0",
-        "trim-newlines": "^3.0.0",
-        "type-fest": "^0.18.0",
-        "yargs-parser": "^20.2.3"
+        "normalize-package-data": "^3.0.2",
+        "read-pkg-up": "^8.0.0",
+        "redent": "^4.0.0",
+        "trim-newlines": "^4.0.2",
+        "type-fest": "^1.2.2",
+        "yargs-parser": "^20.2.9"
       },
       "engines": {
-        "node": ">=10"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/meow/node_modules/type-fest": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
-      "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
       "dev": true,
       "engines": {
         "node": ">=10"
@@ -8379,12 +8510,15 @@
       "optional": true
     },
     "node_modules/quick-lru": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
-      "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
       "dev": true,
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/random-bytes": {
@@ -8427,132 +8561,62 @@
       "dev": true
     },
     "node_modules/read-pkg": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
-      "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-6.0.0.tgz",
+      "integrity": "sha512-X1Fu3dPuk/8ZLsMhEj5f4wFAF0DWoK7qhGJvgaijocXxBmSToKfbFtqbxMO7bVjNA1dmE5huAzjXj/ey86iw9Q==",
       "dev": true,
       "dependencies": {
         "@types/normalize-package-data": "^2.4.0",
-        "normalize-package-data": "^2.5.0",
-        "parse-json": "^5.0.0",
-        "type-fest": "^0.6.0"
+        "normalize-package-data": "^3.0.2",
+        "parse-json": "^5.2.0",
+        "type-fest": "^1.0.1"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/read-pkg-up": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
-      "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-8.0.0.tgz",
+      "integrity": "sha512-snVCqPczksT0HS2EC+SxUndvSzn6LRCwpfSvLrIfR5BKDQQZMaI6jPRC9dYvYFDRAuFEAnkwww8kBBNE/3VvzQ==",
       "dev": true,
       "dependencies": {
-        "find-up": "^4.1.0",
-        "read-pkg": "^5.2.0",
-        "type-fest": "^0.8.1"
+        "find-up": "^5.0.0",
+        "read-pkg": "^6.0.0",
+        "type-fest": "^1.0.1"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/find-up": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "dev": true,
-      "dependencies": {
-        "locate-path": "^5.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "dev": true,
-      "dependencies": {
-        "p-locate": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/p-locate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "dev": true,
-      "dependencies": {
-        "p-limit": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/read-pkg-up/node_modules/type-fest": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
       "dev": true,
       "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/read-pkg/node_modules/hosted-git-info": {
-      "version": "2.8.9",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
-      "dev": true
-    },
-    "node_modules/read-pkg/node_modules/normalize-package-data": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
-      "dev": true,
-      "dependencies": {
-        "hosted-git-info": "^2.1.4",
-        "resolve": "^1.10.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
-      }
-    },
-    "node_modules/read-pkg/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/read-pkg/node_modules/type-fest": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
-      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
       "dev": true,
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/readable-stream": {
@@ -8655,25 +8719,19 @@
       }
     },
     "node_modules/redent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
-      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-4.0.0.tgz",
+      "integrity": "sha512-tYkDkVVtYkSVhuQ4zBgfvciymHaeuel+zFKXShfDnFP5SyVEP7qo70Rf1jTOTCx3vGNAbnEi/xFkcfQVMIBWag==",
       "dev": true,
       "dependencies": {
-        "indent-string": "^4.0.0",
-        "strip-indent": "^3.0.0"
+        "indent-string": "^5.0.0",
+        "strip-indent": "^4.0.0"
       },
       "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/redent/node_modules/indent-string": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/regexp.prototype.flags": {
@@ -10027,15 +10085,18 @@
       }
     },
     "node_modules/strip-indent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
-      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.0.0.tgz",
+      "integrity": "sha512-mnVSV2l+Zv6BLpSD/8V87CW/y9EmmbYzGCIavsnsI6/nwn26DwffM/yztm30Z/I2DY9wdS3vXVCMnHDgZaVNoA==",
       "dev": true,
       "dependencies": {
-        "min-indent": "^1.0.0"
+        "min-indent": "^1.0.1"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/strip-json-comments": {
@@ -10057,55 +10118,57 @@
       "dev": true
     },
     "node_modules/stylelint": {
-      "version": "14.16.1",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.16.1.tgz",
-      "integrity": "sha512-ErlzR/T3hhbV+a925/gbfc3f3Fep9/bnspMiJPorfGEmcBbXdS+oo6LrVtoUZ/w9fqD6o6k7PtUlCOsCRdjX/A==",
+      "version": "15.10.2",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-15.10.2.tgz",
+      "integrity": "sha512-UxqSb3hB74g4DTO45QhUHkJMjKKU//lNUAOWyvPBVPZbCknJ5HjOWWZo+UDuhHa9FLeVdHBZXxu43eXkjyIPWg==",
       "dev": true,
       "dependencies": {
-        "@csstools/selector-specificity": "^2.0.2",
+        "@csstools/css-parser-algorithms": "^2.3.0",
+        "@csstools/css-tokenizer": "^2.1.1",
+        "@csstools/media-query-list-parser": "^2.1.2",
+        "@csstools/selector-specificity": "^3.0.0",
         "balanced-match": "^2.0.0",
         "colord": "^2.9.3",
-        "cosmiconfig": "^7.1.0",
-        "css-functions-list": "^3.1.0",
+        "cosmiconfig": "^8.2.0",
+        "css-functions-list": "^3.2.0",
+        "css-tree": "^2.3.1",
         "debug": "^4.3.4",
-        "fast-glob": "^3.2.12",
+        "fast-glob": "^3.3.0",
         "fastest-levenshtein": "^1.0.16",
         "file-entry-cache": "^6.0.1",
         "global-modules": "^2.0.0",
         "globby": "^11.1.0",
         "globjoin": "^0.1.4",
-        "html-tags": "^3.2.0",
-        "ignore": "^5.2.1",
+        "html-tags": "^3.3.1",
+        "ignore": "^5.2.4",
         "import-lazy": "^4.0.0",
         "imurmurhash": "^0.1.4",
         "is-plain-object": "^5.0.0",
-        "known-css-properties": "^0.26.0",
+        "known-css-properties": "^0.27.0",
         "mathml-tag-names": "^2.1.3",
-        "meow": "^9.0.0",
+        "meow": "^10.1.5",
         "micromatch": "^4.0.5",
         "normalize-path": "^3.0.0",
         "picocolors": "^1.0.0",
-        "postcss": "^8.4.19",
-        "postcss-media-query-parser": "^0.2.3",
+        "postcss": "^8.4.25",
         "postcss-resolve-nested-selector": "^0.1.1",
         "postcss-safe-parser": "^6.0.0",
-        "postcss-selector-parser": "^6.0.11",
+        "postcss-selector-parser": "^6.0.13",
         "postcss-value-parser": "^4.2.0",
         "resolve-from": "^5.0.0",
         "string-width": "^4.2.3",
         "strip-ansi": "^6.0.1",
         "style-search": "^0.1.0",
-        "supports-hyperlinks": "^2.3.0",
+        "supports-hyperlinks": "^3.0.0",
         "svg-tags": "^1.0.0",
         "table": "^6.8.1",
-        "v8-compile-cache": "^2.3.0",
-        "write-file-atomic": "^4.0.2"
+        "write-file-atomic": "^5.0.1"
       },
       "bin": {
-        "stylelint": "bin/stylelint.js"
+        "stylelint": "bin/stylelint.mjs"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": "^14.13.1 || >=16.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -10113,71 +10176,86 @@
       }
     },
     "node_modules/stylelint-config-gds": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-gds/-/stylelint-config-gds-0.3.0.tgz",
-      "integrity": "sha512-mZ0/C2JAneCrMbmBABJGIIczDR/jlacObBggU5j69bMK2TEwp3kwXDd2YZEPmVe1ayIbsZ/HPAV8khK3kfunWw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-gds/-/stylelint-config-gds-1.0.0.tgz",
+      "integrity": "sha512-TlBxYdXLJtPcH0HhSlRmWv2sOgSTezYAiTwOOZ/qc3/hq4IJ1hoGKHalTGZaKK/K7iDcs4AU9NYw7MCYLR5GFw==",
       "dev": true,
       "dependencies": {
-        "stylelint-config-standard": "^29.0.0",
-        "stylelint-config-standard-scss": "^6.1.0"
+        "stylelint-config-standard": "^34.0.0",
+        "stylelint-config-standard-scss": "^10.0.0"
       },
       "peerDependencies": {
-        "stylelint": "^14.14.0"
+        "stylelint": "^15.10.2"
       }
     },
     "node_modules/stylelint-config-recommended": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-9.0.0.tgz",
-      "integrity": "sha512-9YQSrJq4NvvRuTbzDsWX3rrFOzOlYBmZP+o513BJN/yfEmGSr0AxdvrWs0P/ilSpVV/wisamAHu5XSk8Rcf4CQ==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-13.0.0.tgz",
+      "integrity": "sha512-EH+yRj6h3GAe/fRiyaoO2F9l9Tgg50AOFhaszyfov9v6ayXJ1IkSHwTxd7lB48FmOeSGDPLjatjO11fJpmarkQ==",
       "dev": true,
+      "engines": {
+        "node": "^14.13.1 || >=16.0.0"
+      },
       "peerDependencies": {
-        "stylelint": "^14.10.0"
+        "stylelint": "^15.10.0"
       }
     },
     "node_modules/stylelint-config-recommended-scss": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-8.0.0.tgz",
-      "integrity": "sha512-BxjxEzRaZoQb7Iinc3p92GS6zRdRAkIuEu2ZFLTxJK2e1AIcCb5B5MXY9KOXdGTnYFZ+KKx6R4Fv9zU6CtMYPQ==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-12.0.0.tgz",
+      "integrity": "sha512-5Bb2mlGy6WLa30oNeKpZvavv2lowJUsUJO25+OA68GFTemlwd1zbFsL7q0bReKipOSU3sG47hKneZ6Nd+ctrFA==",
       "dev": true,
       "dependencies": {
-        "postcss-scss": "^4.0.2",
-        "stylelint-config-recommended": "^9.0.0",
-        "stylelint-scss": "^4.0.0"
+        "postcss-scss": "^4.0.6",
+        "stylelint-config-recommended": "^12.0.0",
+        "stylelint-scss": "^5.0.0"
       },
       "peerDependencies": {
         "postcss": "^8.3.3",
-        "stylelint": "^14.10.0"
+        "stylelint": "^15.5.0"
       },
       "peerDependenciesMeta": {
         "postcss": {
           "optional": true
         }
+      }
+    },
+    "node_modules/stylelint-config-recommended-scss/node_modules/stylelint-config-recommended": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-12.0.0.tgz",
+      "integrity": "sha512-x6x8QNARrGO2sG6iURkzqL+Dp+4bJorPMMRNPScdvaUK8PsynriOcMW7AFDKqkWAS5wbue/u8fUT/4ynzcmqdQ==",
+      "dev": true,
+      "peerDependencies": {
+        "stylelint": "^15.5.0"
       }
     },
     "node_modules/stylelint-config-standard": {
-      "version": "29.0.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-29.0.0.tgz",
-      "integrity": "sha512-uy8tZLbfq6ZrXy4JKu3W+7lYLgRQBxYTUUB88vPgQ+ZzAxdrvcaSUW9hOMNLYBnwH+9Kkj19M2DHdZ4gKwI7tg==",
+      "version": "34.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-34.0.0.tgz",
+      "integrity": "sha512-u0VSZnVyW9VSryBG2LSO+OQTjN7zF9XJaAJRX/4EwkmU0R2jYwmBSN10acqZisDitS0CLiEiGjX7+Hrq8TAhfQ==",
       "dev": true,
       "dependencies": {
-        "stylelint-config-recommended": "^9.0.0"
+        "stylelint-config-recommended": "^13.0.0"
+      },
+      "engines": {
+        "node": "^14.13.1 || >=16.0.0"
       },
       "peerDependencies": {
-        "stylelint": "^14.14.0"
+        "stylelint": "^15.10.0"
       }
     },
     "node_modules/stylelint-config-standard-scss": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-standard-scss/-/stylelint-config-standard-scss-6.1.0.tgz",
-      "integrity": "sha512-iZ2B5kQT2G3rUzx+437cEpdcnFOQkwnwqXuY8Z0QUwIHQVE8mnYChGAquyKFUKZRZ0pRnrciARlPaR1RBtPb0Q==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-standard-scss/-/stylelint-config-standard-scss-10.0.0.tgz",
+      "integrity": "sha512-bChBEo1p3xUVWh/wenJI+josoMk21f2yuLDGzGjmKYcALfl2u3DFltY+n4UHswYiXghqXaA8mRh+bFy/q1hQlg==",
       "dev": true,
       "dependencies": {
-        "stylelint-config-recommended-scss": "^8.0.0",
-        "stylelint-config-standard": "^29.0.0"
+        "stylelint-config-recommended-scss": "^12.0.0",
+        "stylelint-config-standard": "^33.0.0"
       },
       "peerDependencies": {
         "postcss": "^8.3.3",
-        "stylelint": "^14.14.0"
+        "stylelint": "^15.5.0"
       },
       "peerDependenciesMeta": {
         "postcss": {
@@ -10185,15 +10263,36 @@
         }
       }
     },
+    "node_modules/stylelint-config-standard-scss/node_modules/stylelint-config-recommended": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-12.0.0.tgz",
+      "integrity": "sha512-x6x8QNARrGO2sG6iURkzqL+Dp+4bJorPMMRNPScdvaUK8PsynriOcMW7AFDKqkWAS5wbue/u8fUT/4ynzcmqdQ==",
+      "dev": true,
+      "peerDependencies": {
+        "stylelint": "^15.5.0"
+      }
+    },
+    "node_modules/stylelint-config-standard-scss/node_modules/stylelint-config-standard": {
+      "version": "33.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-33.0.0.tgz",
+      "integrity": "sha512-eyxnLWoXImUn77+ODIuW9qXBDNM+ALN68L3wT1lN2oNspZ7D9NVGlNHb2QCUn4xDug6VZLsh0tF8NyoYzkgTzg==",
+      "dev": true,
+      "dependencies": {
+        "stylelint-config-recommended": "^12.0.0"
+      },
+      "peerDependencies": {
+        "stylelint": "^15.5.0"
+      }
+    },
     "node_modules/stylelint-scss": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-4.7.0.tgz",
-      "integrity": "sha512-TSUgIeS0H3jqDZnby1UO1Qv3poi1N8wUYIJY6D1tuUq2MN3lwp/rITVo0wD+1SWTmRm0tNmGO0b7nKInnqF6Hg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-5.0.1.tgz",
+      "integrity": "sha512-n87iCRZrr2J7//I/QFsDXxFLnHKw633U4qvWZ+mOW6KDAp/HLj06H+6+f9zOuTYy+MdGdTuCSDROCpQIhw5fvQ==",
       "dev": true,
       "dependencies": {
         "postcss-media-query-parser": "^0.2.3",
         "postcss-resolve-nested-selector": "^0.1.1",
-        "postcss-selector-parser": "^6.0.11",
+        "postcss-selector-parser": "^6.0.13",
         "postcss-value-parser": "^4.2.0"
       },
       "peerDependencies": {
@@ -10285,19 +10384,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/stylelint/node_modules/write-file-atomic": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
-      "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
-      "dev": true,
-      "dependencies": {
-        "imurmurhash": "^0.1.4",
-        "signal-exit": "^3.0.7"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
     "node_modules/supertap": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/supertap/-/supertap-3.0.1.tgz",
@@ -10325,16 +10411,16 @@
       }
     },
     "node_modules/supports-hyperlinks": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz",
-      "integrity": "sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.0.0.tgz",
+      "integrity": "sha512-QBDPHyPQDRTy9ku4URNGY5Lah8PAaXs6tAAwp55sL5WCsSW7GIfdf6W5ixfziW+t7wh3GVvHyHHyQ1ESsoRvaA==",
       "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0",
         "supports-color": "^7.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=14.18"
       }
     },
     "node_modules/supports-preserve-symlinks-flag": {
@@ -10707,12 +10793,15 @@
       }
     },
     "node_modules/trim-newlines": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
-      "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-4.1.1.tgz",
+      "integrity": "sha512-jRKj0n0jXWo6kh62nA5TEh3+4igKDXLvzBJcPpiizP7oOolUrYIxmVBG9TOtHYFHoddUk6YvAkGeGoSVTXfQXQ==",
       "dev": true,
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tsconfig-paths": {
@@ -10981,12 +11070,6 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
-    },
-    "node_modules/v8-compile-cache": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
-      "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
-      "dev": true
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.1.0",
@@ -11397,15 +11480,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-    },
-    "node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -72,8 +72,8 @@
     "ava": "^5.1.0",
     "c8": "^8.0.0",
     "standard": "^17.0.0",
-    "stylelint": "^ 14.6.1",
-    "stylelint-config-gds": "^0.3.0"
+    "stylelint": "^ 15.0.0",
+    "stylelint-config-gds": "^1.0.0"
   },
   "engines": {
     "node": "^16.0.0 || ^18.0.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "predev": "rimraf _site",
     "dev": "eleventy --serve --watch",
     "start": "eleventy --serve",
-    "lint": "standard && stylelint '**/*.scss'",
+    "lint": "prettier . --check && standard && stylelint '**/*.scss'",
     "test": "ava",
     "test:watch": "ava --watch",
     "coverage": "c8 ava"
@@ -71,6 +71,7 @@
     "@x-govuk/govuk-eleventy-plugin": "file:./",
     "ava": "^5.1.0",
     "c8": "^8.0.0",
+    "prettier": "^3.0.0",
     "standard": "^17.0.0",
     "stylelint": "^ 15.0.0",
     "stylelint-config-gds": "^1.0.0"
@@ -86,6 +87,26 @@
     "reporter": [
       "text",
       "lcovonly"
+    ]
+  },
+  "prettier": {
+    "semi": false,
+    "singleQuote": true,
+    "trailingComma": "none",
+    "overrides": [
+      {
+        "files": "*.md",
+        "options": {
+          "embeddedLanguageFormatting": "off",
+          "singleQuote": false
+        }
+      },
+      {
+        "files": "*.scss",
+        "options": {
+          "singleQuote": false
+        }
+      }
     ]
   },
   "stylelint": {


### PR DESCRIPTION
* `stylelint-config-gds` has been updated to v1.0.0 to support Stylelint v15
* Stylelint v15 [deprecated its stylistic rules](https://stylelint.io/migration-guide/to-15), and recommends using Prettier to format (S)CSS

This PR updates Stylelint dependencies, and adds Prettier to format all code, except JavaScript which is formatted using StandardJS.