### PR TITLE
Use tags for tags only

### DIFF
--- a/components/document-header/template.njk
+++ b/components/document-header/template.njk
@@ -38,8 +38,7 @@
       {%- if params.tags | length > 0 -%}
         <span aria-hidden="true">&ensp;•&ensp;</span>Tags:
         {%- for tag in params.tags %}
-          {% set item = params.tagPages | includes("data.tag", tag) | first %}
-          <a href="{{ item.url }}" class="govuk-link">{{ item.data.tag }}</a>
+          <a href="/tags/{{ tag | slug }}" class="govuk-link">{{ tag }}</a>
           {%- if not loop.last %}, {% endif %}
         {%- endfor -%}
       {%- endif -%}

--- a/docs/layouts.md
+++ b/docs/layouts.md
@@ -3,8 +3,6 @@ layout: sub-navigation
 order: 3
 title: Layouts
 description: The plugin offers a number of layouts to match the type of content you want write.
-tags:
-  - homepage
 ---
 {% for page in collections["layout"] %}
 

--- a/docs/layouts/layouts.11tydata.js
+++ b/docs/layouts/layouts.11tydata.js
@@ -1,5 +1,4 @@
 module.exports = {
-  tags: ['layout'],
   eleventyComputed: {
     viewSource: data => `https://github.com/x-govuk/govuk-eleventy-plugin/blob/main/docs${data.page.filePathStem}.md?plain=1`
   },

--- a/docs/markdown.md
+++ b/docs/markdown.md
@@ -8,8 +8,6 @@ related:
     - items:
         - text: Markdown Guide
           href: https://www.markdownguide.org
-tags:
-  - homepage
 ---
 
 [[toc]]

--- a/docs/options.md
+++ b/docs/options.md
@@ -3,8 +3,6 @@ layout: sub-navigation
 order: 2
 title: Options
 description: The plugin has a number of options that allow you to customise the appearance of your website.
-tags:
-  - homepage
 ---
 
 You can add options to the second parameter of the `addPlugin` function in Eleventy config file.

--- a/docs/tag.md
+++ b/docs/tag.md
@@ -1,7 +1,6 @@
 ---
 layout: tag
 pagination:
-  addAllPagesToCollections: true
   alias: tag
   data: collections.tags
   size: 1
@@ -10,4 +9,5 @@ eleventyComputed:
   title: "Pages tagged ‘{{ tag }}’"
 eleventyNavigation:
   parent: "Tags"
+eleventyExcludeFromCollections: true  
 ---

--- a/docs/tags.md
+++ b/docs/tags.md
@@ -1,4 +1,5 @@
 ---
 layout: tags
 title: Tags
+eleventyExcludeFromCollections: true
 ---

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -54,8 +54,11 @@ module.exports = function (eleventyConfig) {
       .sort((a, b) => (a.data.order || 0) - (b.data.order || 0))
   )
   eleventyConfig.addCollection('homepage', collection =>
-    collection.getFilteredByTag('homepage')
-      .sort((a, b) => (a.data.order || 0) - (b.data.order || 0))
+    collection.getFilteredByGlob([
+      'docs/options.md',
+      'docs/layouts.md',
+      'docs/markdown.md'
+    ]).sort((a, b) => (a.data.order || 0) - (b.data.order || 0))
   )
 
   // Passthrough

--- a/index.js
+++ b/index.js
@@ -12,7 +12,6 @@ module.exports = function (eleventyConfig, pluginOptions = {}) {
   eleventyConfig.addCollection('ordered', require('./lib/collections/ordered.js'))
   eleventyConfig.addCollection('sitemap', require('./lib/collections/sitemap.js'))
   eleventyConfig.addCollection('tags', require('./lib/collections/tags.js'))
-  eleventyConfig.addCollection('tagPages', require('./lib/collections/tag-pages.js'))
 
   // Extensions and template formats
   eleventyConfig.addExtension('scss', require('./lib/extensions/scss.js'))

--- a/layouts/post.njk
+++ b/layouts/post.njk
@@ -16,8 +16,7 @@
         modified: modified,
         author: author,
         authors: authors,
-        tags: tags,
-        tagPages: collections.tagPages
+        tags: tags
       }) }}
     </div>
 

--- a/layouts/tags.njk
+++ b/layouts/tags.njk
@@ -15,10 +15,10 @@
     }) }}
 
     <ul class="govuk-list govuk-list--bullet">
-      {% for item in collections.tagPages %}
+      {% for tag in collections.tags %}
       <li>
-        <a href="{{ item.url | url }}">{{ item.data.tag }}</a>
-        ({{ collections[item.data.tag] | length }})
+        <a href="/tags/{{ tag | slug }}">{{ tag }}</a>
+        ({{ collections[tag] | length }})
       </li>
       {% endfor %}
     </ul>

--- a/lib/collections/tag-pages.js
+++ b/lib/collections/tag-pages.js
@@ -1,2 +1,0 @@
-module.exports = (collection) =>
-  collection.getAllSorted().filter((item) => item.data.layout === 'tag')


### PR DESCRIPTION
This changes the way that "tags" work, hopefully making it slightly simpler.

One of the main differences is that there's no longer a `tagPages` collection of "posts tagged xxx" pages, instead there’s just the existing `tags` collection, which is just a plain array of tag strings rather than an array of pages.

This has the advantage that you no longer need to pass both `tags` and `collections.tagPages` to the `documentHeader` macro, and instead just pass the tags from the post. The downside is that the macro now needs to make some assumptions about the URL of the tag page, which is now hardcoded to `/tags/{{ tag | slugify }}`.

The other change is to no longer use tags to create the `homepage` and `layout` collection in the docs. Instead the `homepage` collection is constructed manually by passing an array of the 3 pages for the homepage. The `layout` wasn't needed, as far as I can tell.

Once this is merged, we could then update [govuk-design-system-template](https://github.com/x-govuk/govuk-design-history-template), which would allow that to have tag pages without having "post" appear as a tag on every page. I'd also apply the same approach to [Teacher CPD Design History](https://teacher-cpd.design-history.education.gov.uk) which doesn’t currently have tag pages.
