### PR TITLE
Allow for more frontend settings to be overridden

### DIFF
--- a/lib/events/generate-govuk-assets.js
+++ b/lib/events/generate-govuk-assets.js
@@ -4,7 +4,29 @@ const sass = require('sass')
 const rollup = require('rollup')
 const commonJs = require('@rollup/plugin-commonjs')
 const { nodeResolve } = require('@rollup/plugin-node-resolve')
-const { ensureSlash } = require('../utils.js')
+const { ensureSlash, kebabise } = require('../utils.js')
+
+/**
+ * @see {@link https://frontend.design-system.service.gov.uk/sass-api-reference/#settings}
+ */
+const settingKeys = [
+  'brandColour',
+  'textColour',
+  'secondaryTextColour',
+  'canvasBackgroundColour',
+  'bodyBackgroundColour',
+  'focusColour',
+  'focusTextColour',
+  'errorColour',
+  'successColour',
+  'borderColour',
+  'linkColour',
+  'linkVisitedColour',
+  'linkHoverColour',
+  'linkActiveColour',
+  'pageWidth',
+  'fontFamily'
+]
 
 /**
  * Generate GOV.UK Frontend assets
@@ -15,8 +37,15 @@ const { ensureSlash } = require('../utils.js')
  * @returns {function}
  */
 module.exports = async function (dir, pathPrefix, options) {
-  const { imagesPath, fontsPath, brandColour, fontFamily } = options
-  const assetsPath = options.assetsPath || path.join(pathPrefix, 'assets')
+  let { assetsPath, imagesPath, fontsPath } = options
+  assetsPath = assetsPath || path.join(pathPrefix, 'assets')
+
+  const settings = []
+  for (const key of settingKeys) {
+    if (options[key]) {
+      settings.push(`$govuk-${kebabise(key)}: ${options[key]};`)
+    }
+  }
 
   // Get plugin options and set GOV.UK Frontend variables if provided
   const inputFilePath = path.join(__dirname, '../govuk.scss')
@@ -25,8 +54,7 @@ module.exports = async function (dir, pathPrefix, options) {
     assetsPath ? `$govuk-assets-path: "${ensureSlash(assetsPath)}";` : [],
     fontsPath ? `$govuk-fonts-path: "${ensureSlash(fontsPath)}";` : [],
     imagesPath ? `$govuk-images-path: "${ensureSlash(imagesPath)}";` : [],
-    brandColour ? `$govuk-brand-colour: ${brandColour};` : [],
-    fontFamily ? `$govuk-font-family: ${fontFamily};` : [],
+    ...settings,
     inputFile
   ].join('\n')
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -17,6 +17,20 @@ const ensureSlash = (string) => {
 }
 
 /**
+ * Convert camelCase to kebab-case
+ *
+ * @param {string} string camelCase string
+ * @returns kebab-case string
+ */
+const kebabise = (string) => {
+  return string.split('').map((letter, index) => {
+    return letter.toUpperCase() === letter
+      ? `${index !== 0 ? '-' : ''}${letter.toLowerCase()}`
+      : letter
+  }).join('')
+}
+
+/**
  * Normalise value provided to a filter. Checks that a given value exists
  * before performing a transformation.
  *
@@ -34,5 +48,6 @@ const normalise = (value, defaultValue) => {
 
 module.exports = {
   ensureSlash,
+  kebabise,
   normalise
 }


### PR DESCRIPTION
`govuk-frontend` allows [a number of values in its SCSS styles to be modified](https://frontend.design-system.service.gov.uk/sass-api-reference/#settings) but currently we only allow `$govuk-brand-colour` and `$govuk-font-family` to be modified.

This PR adds support for many more, but not all. I’ve excluded those that will be deprecated in v5.0, as well as those relating to form controls as this plugin is not designed to be used on sites that include forms.

Given the number of options, wondering if they should be moved under a top-level option name; perhaps `settings`? We can still keep `brandColour` and `fontFamily`, but deprecate them in favour of `settings.brandColour` and `settings.fontFamily`.

This change was done primarily for [my own interests](https://paulrobertlloyd.com/2023/272/a1/classnames/), but worth pointing out that without these changes, it is not currently possible to create a site that uses the same link colours as the [MOD.UK Design System](https://design-system.service.mod.gov.uk) or page background colours as used by the [Home Office Design System](https://design.homeoffice.gov.uk); this change would make that possible.

(See also this upstream fix to `govuk-frontend`: https://github.com/alphagov/govuk-frontend/pull/4268)

## To do

- [ ] Move options under a parent option value?
- [ ] Add documentation