### PR TITLE
Fix missing layouts on ‘Getting started’ and ‘Layouts’ pages

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -107,9 +107,9 @@ Open the preview URL in your browser to see this new page appear using GOV.UK st
 
 ## Choose a layout
 
-This plugin provides {{ collections["layout"] | length }} different layouts, each with different options you can provide in the front matter:
+This plugin provides {{ collections.layout | length }} different layouts, each with different options you can provide in the front matter:
 
-{% for page in collections["layout"] %}
+{% for page in collections.layout %}
 
 * [{{ page.data.title }}]({{ page.url | url }}) – {{ page.data.description }}
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ eleventyComputed:
   title: "{{ pkg.description }}"
 ---
 <div class="govuk-grid-row">
-{% for item in collections["homepage"] %}
+{% for item in collections.homepage %}
   <section class="govuk-grid-column-one-third-from-desktop govuk-!-margin-bottom-8">
     <h2 class="govuk-heading-m govuk-!-font-size-27">{{ item.data.title | smart }}</h2>
     <p class="govuk-body">{{ item.data.description | markdown("inline") }}</p>

--- a/docs/layouts.md
+++ b/docs/layouts.md
@@ -4,7 +4,7 @@ order: 3
 title: Layouts
 description: The plugin offers a number of layouts to match the type of content you want write.
 ---
-{% for page in collections["layout"] %}
+{% for page in collections.layout %}
 
 * [{{ page.data.title }}]({{ page.url | url }}) – {{ page.data.description }}
 

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -50,8 +50,9 @@ module.exports = function (eleventyConfig) {
 
   // Collections
   eleventyConfig.addCollection('layout', collection =>
-    collection.getFilteredByTag('layout')
-      .sort((a, b) => (a.data.order || 0) - (b.data.order || 0))
+    collection.getFilteredByGlob([
+      'docs/layouts/*.md'
+    ]).sort((a, b) => (a.data.order || 0) - (b.data.order || 0))
   )
   eleventyConfig.addCollection('homepage', collection =>
     collection.getFilteredByGlob([


### PR DESCRIPTION
In #192 we moved away from using tags to create collections as they were appearing in tag lists. However, when we made this change, we forgot to create the `layout` collection by glowing for markdown files in the `docs/layouts` directory. Fixes #200

Also: use dot notation for referencing collections.