### PR TITLE
Add navigation option

### DIFF
--- a/components/header/template.njk
+++ b/components/header/template.njk
@@ -1,8 +1,10 @@
+{%- from "x-govuk/components/primary-navigation/macro.njk" import xGovukPrimaryNavigation -%}
 {%- from "../site-search/macro.njk" import appSiteSearch -%}
 {%- set headerType = "no-border" if
   layout == "product" or
   layout == "collection"
 -%}
+{%- set headerType = "full-width-border" if params.navigation -%}
 <header class="govuk-header app-header{% if headerType %} app-header--{{ headerType }}{% endif %}" role="banner" data-module="govuk-header">
   <div class="govuk-header__container govuk-width-container app-header__container">
     <div class="govuk-header__logo app-header__logo">
@@ -26,3 +28,7 @@
     {{ appSiteSearch(params.search) if params.search.indexPath | indent(4) }}
   </div>
 </header>
+{{ xGovukPrimaryNavigation({
+  visuallyHiddenTitle: params.navigation.visuallyHiddenTitle,
+  items: params.navigation.items | currentPage(page.url)
+}) if params.navigation }}

--- a/index.js
+++ b/index.js
@@ -27,6 +27,10 @@ module.exports = function (eleventyConfig, pluginOptions = {}) {
 
   // Filters
   eleventyConfig.addFilter('date', require('./lib/filters/date.js'))
+  eleventyConfig.addFilter(
+    'currentPage',
+    require('./lib/filters/current-page.js')
+  )
   eleventyConfig.addFilter('includes', require('./lib/filters/includes.js'))
   eleventyConfig.addFilter(
     'itemsFromCollection',

--- a/lib/filters/current-page.js
+++ b/lib/filters/current-page.js
@@ -1,0 +1,13 @@
+/**
+ * Indicate which is the current item in navigation items
+ * @param {Array} array - Navigation items
+ * @param {string} pageUrl - URL of current page
+ * @returns {Array} Navigation items
+ */
+module.exports = (array, pageUrl) => {
+  return array.map((item) => {
+    item.current = pageUrl.startsWith(item.href)
+
+    return item
+  })
+}


### PR DESCRIPTION
Be nice to get a big feature into the 6.0 release, and was thinking the ability to add primary navigation items from the plugin config.

Unfortunately, it’s thrown up a few upstream issues with the prototype components:

## Item padding

We’ve adjusted the spacing between items, and no longer have selected items bleed outside the confines of the container, however the items don’t line up with other content on the page, and have too much space between them:

<img width="499" alt="Screenshot 2023-12-12 at 00 12 51" src="https://github.com/x-govuk/govuk-eleventy-plugin/assets/813383/e11432c4-80fb-49d4-a749-70c6ca5e3de7">

### Proposed solution

I think this can be resolved by removing the left and right padding [from navigation items](https://github.com/x-govuk/govuk-prototype-components/blob/83bbd0651dd0c29c93c49b890b0cd032fbabdbd7/x-govuk/components/primary-navigation/_primary-navigation.scss#L20-L29):

```diff
  .x-govuk-primary-navigation__item {
    box-sizing: border-box;
    display: block;
    float: left;
    line-height: 55px;
    height: 55px;
-   padding: 0 govuk-spacing(3);
    position: relative;
    margin-right: govuk-spacing(6)
  }
```

## Masthead component is too opinionated

The masthead component has a top margin of -10px to account for the blue border below the header. However, this means if anything else appears before it, it gets partially obscured:

<img width="400" alt="Screenshot 2023-12-12 at 00 29 15" src="https://github.com/x-govuk/govuk-eleventy-plugin/assets/813383/11a494ef-82cc-4db1-a952-2a100617798b">

<img width="400" alt="Screenshot 2023-12-12 at 00 29 49" src="https://github.com/x-govuk/govuk-eleventy-plugin/assets/813383/6fac71b0-5776-49b8-a1f8-3e37f2b4c654">

If you remove the top margin, and don’t have an adaptation to the header to add a full-width bottom border, you get this:

<img width="400" alt="Screenshot 2023-12-12 at 00 38 10" src="https://github.com/x-govuk/govuk-eleventy-plugin/assets/813383/ae4d889e-b457-4a63-8160-ccc831e06196">

These components are all frustratingly dependent on each other in different ways.

### Proposed solution

The negative margin seems like a code smell, so should probably be removed from the masthead component.

Then, in this plugin’s layouts, we need to programmatically decide when to add a header modifying class to give it a full border width.