### PR TITLE
Add Eleventy’s HTML base plugin

### DIFF
--- a/components/document-list/template.njk
+++ b/components/document-list/template.njk
@@ -5,7 +5,7 @@
   {% for item in params.items %}
     <li class="app-document-list__item">
       <h{{ headingLevel }} class="app-document-list__item-title">
-        <a class="govuk-link" href="{{ item.url | url | pretty }}">{{ item.data.title | smart }}</a>
+        <a class="govuk-link" href="{{ item.url | pretty }}">{{ item.data.title | smart }}</a>
       </h{{ headingLevel }}>
       {% if item.data.description %}
       <p class="app-document-list__item-description">

--- a/components/header/template.njk
+++ b/components/header/template.njk
@@ -2,7 +2,7 @@
 <header class="govuk-header app-header" role="banner" data-module="govuk-header">
   <div class="govuk-header__container govuk-width-container app-header__container">
     <div class="govuk-header__logo app-header__logo">
-      <a href="{{ params.homepageUrl | default("/") | url }}" class="govuk-header__link govuk-header__link--homepage">
+      <a href="{{ params.homepageUrl | default("/") }}" class="govuk-header__link govuk-header__link--homepage">
         {% if params.logotype == "x-govuk" %}
           {% include "./_x-govuk.svg" %}
         {% elif params.logotype.html %}

--- a/components/site-search/template.njk
+++ b/components/site-search/template.njk
@@ -1,4 +1,4 @@
-<div class="app-site-search govuk-!-display-none-print" data-module="app-site-search" data-search-index="{{ params.indexPath | url }}">
+<div class="app-site-search govuk-!-display-none-print" data-module="app-site-search" data-search-index="{{ params.indexPath }}">
   <label class="govuk-visually-hidden" for="app-site-search__input">{{ params.label | default("Search site") }}</label>
-  <a class="app-site-search__link govuk-link-no-visited" href="{{ params.sitemapPath | url }}">Sitemap</a>
+  <a class="app-site-search__link govuk-link-no-visited" href="{{ params.sitemapPath }}">Sitemap</a>
 </div>

--- a/docs/404.md
+++ b/docs/404.md
@@ -7,4 +7,4 @@ permalink: 404.html
 
 If you entered a web address please check it was correct.
 
-You can browse from [the homepage]({{ "/" | url }}) or use the [sitemap]({{ "/sitemap" | url }}) to find the information you need.
+You can browse from [the homepage](/) or use the [sitemap](/sitemap) to find the information you need.

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -111,6 +111,6 @@ This plugin provides {{ collections.layout | length }} different layouts, each w
 
 {% for page in collections.layout %}
 
-- [{{ page.data.title }}]({{ page.url | url }}) – {{ page.data.description }}
+- [{{ page.data.title }}]({{ page.url }}) – {{ page.data.description }}
 
 {% endfor %}

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ eleventyComputed:
   <section class="govuk-grid-column-one-third-from-desktop govuk-!-margin-bottom-8">
     <h2 class="govuk-heading-m govuk-!-font-size-27">{{ item.data.title | smart }}</h2>
     <p class="govuk-body">{{ item.data.description | markdown("inline") }}</p>
-    <p class="govuk-body"><a class="govuk-link govuk-!-font-weight-bold" href="{{ item.url | url }}">Learn about {{ item.data.title | smart | lower }}</a></p>
+    <p class="govuk-body"><a class="govuk-link govuk-!-font-weight-bold" href="{{ item.url }}">Learn about {{ item.data.title | smart | lower }}</a></p>
   </section>
 {% endfor %}
   <section class="govuk-grid-column-full">

--- a/docs/layouts.md
+++ b/docs/layouts.md
@@ -7,7 +7,7 @@ description: The plugin offers a number of layouts to match the type of content 
 
 {% for page in collections.layout %}
 
-- [{{ page.data.title }}]({{ page.url | url }}) – {{ page.data.description }}
+- [{{ page.data.title }}]({{ page.url }}) – {{ page.data.description }}
 
 {% endfor %}
 

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+const { EleventyHtmlBasePlugin } = require("@11ty/eleventy")
+
 module.exports = function (eleventyConfig, pluginOptions = {}) {
   const { pathPrefix } = eleventyConfig
 
@@ -39,6 +41,7 @@ module.exports = function (eleventyConfig, pluginOptions = {}) {
   })
 
   // Plugins
+  eleventyConfig.addPlugin(EleventyHtmlBasePlugin)
   eleventyConfig.addPlugin(require('@11ty/eleventy-navigation'))
   eleventyConfig.addPlugin(require('@11ty/eleventy-plugin-rss'))
 

--- a/layouts/base.njk
+++ b/layouts/base.njk
@@ -34,23 +34,23 @@
 {% from "components/prose-scope/macro.njk" import appProseScope %}
 
 {% block headIcons %}
-  <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="{{ options.icons.shortcut | url }}" type="image/x-icon">
-  <link rel="mask-icon" href="{{ options.icons.mask | url }}" color="{{ themeColor }}">
-  <link rel="apple-touch-icon" href="{{ options.icons.touch | url }}">
+  <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="{{ options.icons.shortcut }}" type="image/x-icon">
+  <link rel="mask-icon" href="{{ options.icons.mask }}" color="{{ themeColor }}">
+  <link rel="apple-touch-icon" href="{{ options.icons.touch }}">
 {% endblock %}
 
 {% block head %}
-  <link rel="stylesheet" href="{{ '/assets/govuk.css' | url | absoluteUrl(options.url) }}">
+  <link rel="stylesheet" href="{{ '/assets/govuk.css' | absoluteUrl(options.url) }}">
   {% for stylesheet in options.stylesheets %}
-  <link rel="stylesheet" href="{{ stylesheet | url | absoluteUrl(options.url) }}">
+  <link rel="stylesheet" href="{{ stylesheet | absoluteUrl(options.url) }}">
   {% endfor %}
 
-  <meta property="og:url" content="{{ page.url | url | absoluteUrl(options.url) }}">
+  <meta property="og:url" content="{{ page.url | absoluteUrl(options.url) }}">
   <meta property="og:title" content="{{ title }}">
   {% if description %}<meta property="og:description" name="description" content="{{ description | markdown("inline") | striptags(true) }}">{% endif %}
   {% if opengraphImage %}<meta name="twitter:card" content="summary_large_image">{% endif %}
-  {% if opengraphImage.src %}<meta name="twitter:image" content="{{ opengraphImage.src | url | absoluteUrl(options.url) }}">
-  <meta property="og:image" content="{{ opengraphImage.src | url | absoluteUrl(options.url) }}">{% endif %}
+  {% if opengraphImage.src %}<meta name="twitter:image" content="{{ opengraphImage.src | absoluteUrl(options.url) }}">
+  <meta property="og:image" content="{{ opengraphImage.src | absoluteUrl(options.url) }}">{% endif %}
   {% if opengraphImage.alt %}<meta property="og:image:alt" content="{{ opengraphImage.alt }}">{% endif %}
 {% endblock %}
 
@@ -70,7 +70,7 @@
 {% endblock %}
 
 {% block bodyEnd %}
-  <script src="{{ '/assets/govuk.js' | url }}" type="module"></script>
+  <script src="/assets/govuk.js" type="module"></script>
   <script>document.documentElement.classList.remove('no-js')</script>
   {% block scripts %}{% endblock %}
 {% endblock %}

--- a/layouts/product.njk
+++ b/layouts/product.njk
@@ -10,12 +10,12 @@
       html: description | markdown("inline") | noOrphans
     } if description,
     startButton: {
-      href: startButton.href | url,
+      href: startButton.href,
       text: startButton.text
     } if startButton,
     image: {
       alt: image.alt,
-      src: image.src | url
+      src: image.src
     } if image,
     breadcrumbs: {
       classes: "govuk-!-display-none-print govuk-!-margin-bottom-0",

--- a/layouts/search-index.njk
+++ b/layouts/search-index.njk
@@ -7,6 +7,6 @@
     "hasFrontmatterDate": {{ item.data.date !== undefined }},
     "date": {{ item.date | date("d LLLL y") | dump | safe }},
     "templateContent": {{ item.templateContent | tokenize | dump | safe }},
-    "url": {{ item.url | url | pretty | dump | safe }}
+    "url": {{ item.url | pretty | dump | safe }}
   }{% if not loop.last %},{% endif %}
 {% endfor %}]

--- a/layouts/sitemap.njk
+++ b/layouts/sitemap.njk
@@ -27,7 +27,7 @@
     {% for item in collections.sitemap | eleventyNavigation(options.homeKey) %}
       <div class="govuk-!-margin-bottom-4">
         <h2 class="govuk-heading-s govuk-!-margin-bottom-1">
-          <a class="govuk-link" href="{{ item.url | url | pretty }}">{{ item.title | smart }}</a>
+          <a class="govuk-link" href="{{ item.url | pretty }}">{{ item.title | smart }}</a>
         </h2>
         {% if item.excerpt %}
           <p class="govuk-body">{{ item.excerpt | markdown("inline") | striptags(true) }}</p>


### PR DESCRIPTION
Fixes #221. Means we can remove the need for, and multiple placement of the `url` filter.