### PR TITLE
Only include content pages in ordered collection

### DIFF
--- a/lib/collections/ordered.js
+++ b/lib/collections/ordered.js
@@ -1,6 +1,6 @@
 module.exports = (collection) =>
   collection
-    .getAll()
+    .getFilteredByGlob('**/*.md')
     .filter((item) => !/^tag/.test(item.data.layout))
     .sort((a, b) => {
       if (


### PR DESCRIPTION
With the addition of a settings.scss file, we can see that this is being included in the sub-navigation, albeit hidden because it doesn’t have a title:

```html
<ul class="x-govuk-sub-navigation__section">
  <li class="x-govuk-sub-navigation__section-item">
    <a class="x-govuk-sub-navigation__link" href="/govuk-eleventy-plugin/assets/sass/settings.css"></a>
  </li>
  <li class="x-govuk-sub-navigation__section-item">
    <a class="x-govuk-sub-navigation__link" href="/govuk-eleventy-plugin/get-started/">Get started</a>
  </li>
  …
```

This PR changes the ‘ordered’ collection that populates the side navigation items to only search for Markdown files.