### PR TITLE
Add option to sub navigation layout to choose from which page to show navigation items below

### DIFF
--- a/docs/layouts/sub-navigation.md
+++ b/docs/layouts/sub-navigation.md
@@ -19,4 +19,8 @@ title: Page title
 Page content
 ```
 
-Use [common front matter options](/layouts#common-front-matter-options) to customise which items and content appear within a page.
+In addition to [common front matter options](/layouts#common-front-matter-options), this layout also accepts the following options:
+
+| Name           | Type   | Description                                                                                                                                                |
+| :------------- | :----- | :--------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **sectionKey** | string | Parent navigation key (usually a page title) to show items below in the sub navigation. Default is `homeKey` value provided in [plugin options](/options). |

--- a/layouts/sub-navigation.njk
+++ b/layouts/sub-navigation.njk
@@ -11,7 +11,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-quarter-from-desktop">
       {{ xGovukSubNavigation({
-        items: collections.ordered | eleventyNavigation(options.homeKey) | itemsFromNavigation(page.url, { pathPrefix: options.pathPrefix })
+        items: collections.ordered | eleventyNavigation(sectionKey or options.homeKey) | itemsFromNavigation(page.url, { pathPrefix: options.pathPrefix })
       }) }}
     </div>
     <div class="govuk-grid-column-three-quarters-from-desktop">


### PR DESCRIPTION
Somewhat related to #220. This option on the sub navigation layout allows you to decide which page to show navigation items below.

Currently, what ever page you are on, the sub navigation lists all pages that are nested below the home page.

However, if you are to split a site up into multiple sections, it’s likely that you would want to show any sub navigation items below the section linked to from the primary navigation. This change makes that possible.