### PR TITLE
Update `govuk-prototype-components` dependency

### DIFF
--- a/components/header/_header.scss
+++ b/components/header/_header.scss
@@ -2,6 +2,14 @@
 // See: https://github.com/alphagov/govuk-design-system/blob/master/src/stylesheets/components/_header.scss
 
 @include govuk-exports("app-header") {
+  .app-header--full-width-border {
+    border-bottom: $govuk-border-width-wide solid $govuk-brand-colour;
+  }
+
+  .app-header--no-border {
+    border-bottom: 0;
+  }
+
   // Override the default 33% width on the logo in GOV.UK Frontend (prevents
   // unnecessary wrapping of product name on smaller tablet / desktop
   // viewports)

--- a/components/header/template.njk
+++ b/components/header/template.njk
@@ -1,5 +1,9 @@
 {%- from "../site-search/macro.njk" import appSiteSearch -%}
-<header class="govuk-header app-header" role="banner" data-module="govuk-header">
+{%- set headerType = "no-border" if
+  layout == "product" or
+  layout == "collection"
+-%}
+<header class="govuk-header app-header{% if headerType %} app-header--{{ headerType }}{% endif %}" role="banner" data-module="govuk-header">
   <div class="govuk-header__container govuk-width-container app-header__container">
     <div class="govuk-header__logo app-header__logo">
       <a href="{{ params.homepageUrl | default("/") }}" class="govuk-header__link govuk-header__link--homepage">

--- a/layouts/base.njk
+++ b/layouts/base.njk
@@ -29,7 +29,7 @@
 {% from "components/document-header/macro.njk" import appDocumentHeader %}
 {% from "components/document-list/macro.njk" import appDocumentList %}
 {% from "components/footer/macro.njk" import appFooter %}
-{% from "components/header/macro.njk" import appHeader %}
+{% from "components/header/macro.njk" import appHeader with context %}
 {% from "components/prose-scope/macro.njk" import appProseScope %}
 
 {% block headIcons %}

--- a/layouts/product.njk
+++ b/layouts/product.njk
@@ -2,7 +2,6 @@
 
 {% block main %}
   {{ xGovukMasthead({
-    classes: "x-govuk-masthead--large",
     title: {
       html: title | smart
     } if title,

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@11ty/eleventy-plugin-rss": "^1.1.2",
         "@rollup/plugin-commonjs": "^25.0.0",
         "@rollup/plugin-node-resolve": "^15.0.0",
-        "@x-govuk/govuk-prototype-components": "^2.2.0",
+        "@x-govuk/govuk-prototype-components": "^3.0.0",
         "deepmerge": "^4.2.2",
         "govuk-frontend": "^5.0.0",
         "luxon": "^3.0.1",
@@ -1333,21 +1333,21 @@
       "link": true
     },
     "node_modules/@x-govuk/govuk-prototype-components": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@x-govuk/govuk-prototype-components/-/govuk-prototype-components-2.2.2.tgz",
-      "integrity": "sha512-QZryE59lmhexVyUmnuw9Dx4YCXHTla8+KgAP+kBq1aDtOlvPf5ta0M4SqjTs7LxA9c31KijR4+7TszTOOwkwaA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@x-govuk/govuk-prototype-components/-/govuk-prototype-components-3.0.0.tgz",
+      "integrity": "sha512-rv8HLEc7R4ExZnHwrMC+vopNYlj2x52/ck26sBFI9ovtjd2Us3PwrcYyXQZLPXk0lVdz7HIzz22eVPO6ZsSUfA==",
       "dependencies": {
         "accessible-autocomplete": "^2.0.4",
         "eventslibjs": "^1.2.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=18"
       },
       "optionalDependencies": {
         "govuk-prototype-kit": "^13.14.1"
       },
       "peerDependencies": {
-        "govuk-frontend": "^4.0.0 || ^5.0.0"
+        "govuk-frontend": "^5.0.0"
       }
     },
     "node_modules/a-sync-waterfall": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@11ty/eleventy-plugin-rss": "^1.1.2",
     "@rollup/plugin-commonjs": "^25.0.0",
     "@rollup/plugin-node-resolve": "^15.0.0",
-    "@x-govuk/govuk-prototype-components": "^2.2.0",
+    "@x-govuk/govuk-prototype-components": "^3.0.0",
     "deepmerge": "^4.2.2",
     "govuk-frontend": "^5.0.0",
     "luxon": "^3.0.1",


### PR DESCRIPTION
- Add header modifier based on layout used to prevent gap appearing between header and masthead
- Remove deprecated `large` modifier on masthead component