### PR TITLE
Add documentation for new `navigation` option

### DIFF
--- a/components/header/template.njk
+++ b/components/header/template.njk
@@ -1,6 +1,5 @@
-{%- from "x-govuk/components/primary-navigation/macro.njk" import xGovukPrimaryNavigation -%}
 {%- from "../site-search/macro.njk" import appSiteSearch -%}
-{%- if params.navigation -%}
+{%- if options.navigation -%}
   {%- set headerType = "full-width-border" -%}
 {% elif layout == "product" or layout == "collection" %}
   {%- set headerType = "no-border" -%}
@@ -28,7 +27,3 @@
     {{ appSiteSearch(params.search) if params.search.indexPath | indent(4) }}
   </div>
 </header>
-{{ xGovukPrimaryNavigation({
-  visuallyHiddenTitle: params.navigation.visuallyHiddenTitle,
-  items: params.navigation.items | currentPage(page.url)
-}) if params.navigation }}

--- a/docs/options.md
+++ b/docs/options.md
@@ -21,8 +21,6 @@ module.exports = function(eleventyConfig) {
 }
 ```
 
-## Plugin options
-
 | Name                  | Type    | Description                                                                                                                                                                                              |
 | :-------------------- | :------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **icons.mask**        | string  | Override default GOV.UK SVG mask icon.                                                                                                                                                                   |
@@ -39,9 +37,10 @@ module.exports = function(eleventyConfig) {
 | **stylesheets**       | Array   | Additional stylesheets to load after application styles.                                                                                                                                                 |
 | **url**               | string  | The URL of your website. Optional, but required to have valid canonical URLs in Open Graph meta data.                                                                                                    |
 | **header**            | object  | See [header](#options-for-header).                                                                                                                                                                       |
+| **navigation**        | object  | See [navigation](#options-for-navigation).                                                                                                                                                               |
 | **footer**            | object  | See [footer](#options-for-footer).                                                                                                                                                                       |
 
-### Options for header
+## Options for header
 
 In addition to the [options available for the header component](https://design-system.service.gov.uk/components/header/), the following options can also be set:
 
@@ -64,7 +63,22 @@ Options for site search. See [adding a site search](../search).
 | **indexPath**   | string | Path to search index file. If set, a search input will be shown in the header. |
 | **sitemapPath** | string | Path to sitemap page.                                                          |
 
-### Options for footer
+## Options for navigation
+
+| Name                    | Type   | Description                                                                                                                |
+| :---------------------- | :----- | :------------------------------------------------------------------------------------------------------------------------- |
+| **visuallyHiddenTitle** | string | Hidden title for header navigation.                                                                                        |
+| **items**               | Array  | An array of navigation links to shown within the header navigation. See [navigation.items](#options-for-navigation.items). |
+
+### Options for navigation.items
+
+| Name        | Type   | Description                                                        |
+| :---------- | :----- | :----------------------------------------------------------------- |
+| **text**    | string | **Required**. Text of the navigation link.                         |
+| **href**    | array  | **Required**. The value of the navigation link’s `href` attribute. |
+| **classes** | string | Classes to add to the navigation item.                             |
+
+## Options for footer
 
 In addition to the [options available for the footer component](https://design-system.service.gov.uk/components/footer/), the following options can also be set:
 

--- a/layouts/base.njk
+++ b/layouts/base.njk
@@ -22,6 +22,7 @@
 {% from "govuk/components/pagination/macro.njk" import govukPagination %}
 
 {% from "x-govuk/components/masthead/macro.njk" import xGovukMasthead %}
+{% from "x-govuk/components/primary-navigation/macro.njk" import xGovukPrimaryNavigation %}
 {% from "x-govuk/components/related-navigation/macro.njk" import xGovukRelatedNavigation %}
 {% from "x-govuk/components/sub-navigation/macro.njk" import xGovukSubNavigation %}
 
@@ -72,6 +73,10 @@
 
 {% block header %}
   {{ appHeader(options.header) }}
+  {{ xGovukPrimaryNavigation({
+    visuallyHiddenTitle: options.navigation.visuallyHiddenTitle,
+    items: options.navigation.items | currentPage(page.url)
+  }) if options.navigation }}
 {% endblock %}
 
 {% block footer %}


### PR DESCRIPTION
Fixes #232.

Also make `navigation` a top-level option (as opposed to `header.navigation`.