### PR TITLE
Ensure masthead component appears within `main` landmark on product layout

### DIFF
--- a/layouts/product.njk
+++ b/layouts/product.njk
@@ -1,32 +1,35 @@
 {% extends "layouts/base.njk" %}
 
 {% block main %}
-  {{ xGovukMasthead({
-    title: {
-      html: title | smart
-    } if title,
-    description: {
-      html: description | markdown("inline") | noOrphans
-    } if description,
-    startButton: {
-      href: startButton.href,
-      text: startButton.text
-    } if startButton,
-    image: {
-      alt: image.alt,
-      src: image.src
-    } if image,
-    breadcrumbs: {
-      classes: "govuk-!-display-none-print",
-      items: breadcrumbItems
-    } if showBreadcrumbs
-  }) }}
+  <main id="main-content" role="main" {%- if mainLang %} lang="{{ mainLang }}"{% endif %}>
+    {{ xGovukMasthead({
+      title: {
+        html: title | smart
+      } if title,
+      description: {
+        html: description | markdown("inline") | noOrphans
+      } if description,
+      startButton: {
+        href: startButton.href,
+        text: startButton.text
+      } if startButton,
+      image: {
+        alt: image.alt,
+        src: image.src
+      } if image,
+      breadcrumbs: {
+        classes: "govuk-!-display-none-print",
+        items: breadcrumbItems
+      } if showBreadcrumbs
+    }) }}
+    <div class="govuk-main-wrapper {%- if mainClasses %} {{ mainClasses }}{% endif %}">
+      <div class="govuk-width-container {%- if containerClasses %} {{ containerClasses }}{% endif %}">
+        {% block content %}
+          {{ appProseScope(content) if content }}
 
-  {{ super() }}
-{% endblock %}
-
-{% block content %}
-  {{ appProseScope(content) if content }}
-
-  {% include "layouts/shared/related.njk" %}
+          {% include "layouts/shared/related.njk" %}
+        {% endblock %}
+      </div>
+    </div>
+  </main>
 {% endblock %}


### PR DESCRIPTION
Fixes #169. Closes #170.

With a fresh set of eyes on this, as well as another ([really rather strange](https://github.com/x-govuk/govuk-eleventy-plugin/issues/169#issuecomment-1892591367)) issue raising its head as a result of the masthead not appearing within the main container, this PR updates the product layout to overwrite the `main` template block:

* `<main>` contains the masthead, and keeps its `id` and `lang` attributes
* `beforeContent` template block is removed; this is primarily used for breadcrumbs which can be added to/via the masthead component
* A `div` with class `govuk-main-wrapper`, and which accepts `mainClasses` is used to wrap the content area below the masthead component, essentially replicating the classes and nesting that is used for other layouts.

Thanks to @keithkennedyHO for reporting in #169 and submitting a long neglected fix in #170, for Adam Liptrot reporting the layout issues on Windows and Android; shame on me for not addressing this issue sooner!