### PR TITLE
Add support for (Atom) feeds

### DIFF
--- a/docs/feed.md
+++ b/docs/feed.md
@@ -29,10 +29,8 @@ To make the feed discoverable, add the full URL of your feed as `feedUrl` within
 const govukEleventyPlugin = require('@x-govuk/govuk-eleventy-plugin')
 
 eleventyConfig.addPlugin(govukEleventyPlugin, {
-  feedUrl: 'https://your-website.example/feed.xml',
-  [...]
+  feedUrl: 'https://your-website.example/feed.xml'
 })
-```
 
 This will then add an invisible `<link>` to the feed within the `<head>` of every page to enable feed readers to easily find the feed.
 

--- a/docs/feed.md
+++ b/docs/feed.md
@@ -5,7 +5,7 @@ title: Adding a feed
 description: Allow people to subscribe to your posts and read them in a feed reader
 ---
 
-You can add a feed using the [XML Atom format](https://en.wikipedia.org/wiki/Atom_(web_standard)) by following these instructions.
+You can add a feed using the [XML Atom format](<https://en.wikipedia.org/wiki/Atom_(web_standard)>) by following these instructions.
 
 ## Create a feed
 

--- a/docs/feed.md
+++ b/docs/feed.md
@@ -41,7 +41,7 @@ To make the feed discoverable, add the full URL of your feed as `feedUrl` within
 const govukEleventyPlugin = require('@x-govuk/govuk-eleventy-plugin')
 
 eleventyConfig.addPlugin(govukEleventyPlugin, {
-  feedUrl: 'https://your-website.example/feed.xml'
+  feedUrl: 'feed.xml'
 })
 ```
 

--- a/docs/feed.md
+++ b/docs/feed.md
@@ -35,3 +35,4 @@ eleventyConfig.addPlugin(govukEleventyPlugin, {
 This will then add an invisible `<link>` to the feed within the `<head>` of every page to enable feed readers to easily find the feed.
 
 You may also want to link to the feed within your site itself.
+```

--- a/docs/feed.md
+++ b/docs/feed.md
@@ -21,6 +21,18 @@ permalink: /feed.xml
 
 The `permalink` value is the location of the generated feed.
 
+## Create a collection of posts
+
+The feed will include all pages in a collection called 'post'.
+
+You can create this by adding some code to your `eleventy.config.js`:
+
+```js
+eleventyConfig.addCollection('post', (collection) => {
+  return collection.getFilteredByGlob('app/posts/*.md')
+})
+```
+
 ## Add the URL of your feed to your options
 
 To make the feed discoverable, add the full URL of your feed as `feedUrl` within the options for this plugin in your `.eleventy.config.js` options file:
@@ -31,8 +43,8 @@ const govukEleventyPlugin = require('@x-govuk/govuk-eleventy-plugin')
 eleventyConfig.addPlugin(govukEleventyPlugin, {
   feedUrl: 'https://your-website.example/feed.xml'
 })
+```
 
 This will then add an invisible `<link>` to the feed within the `<head>` of every page to enable feed readers to easily find the feed.
 
 You may also want to link to the feed within your site itself.
-```

--- a/docs/feed.md
+++ b/docs/feed.md
@@ -1,0 +1,39 @@
+---
+layout: sub-navigation
+order: 7
+title: Adding a feed
+description: Allow people to subscribe to your posts and read them in a feed reader
+---
+
+You can add a feed using the [XML Atom format](https://en.wikipedia.org/wiki/Atom_(web_standard)) by following these instructions.
+
+## Create a feed
+
+To create a feed, add a file named `feed.njk` with the following content:
+
+```yaml
+---
+eleventyExcludeFromCollections: true
+layout: feed
+permalink: /feed.xml
+---
+```
+
+The `permalink` value is the location of the generated feed.
+
+## Add the URL of your feed to your options
+
+To make the feed discoverable, add the full URL of your feed as `feedUrl` within the options for this plugin in your `.eleventy.config.js` options file:
+
+```js
+const govukEleventyPlugin = require('@x-govuk/govuk-eleventy-plugin')
+
+eleventyConfig.addPlugin(govukEleventyPlugin, {
+  feedUrl: 'https://your-website.example/feed.xml',
+  [...]
+})
+```
+
+This will then add an invisible `<link>` to the feed within the `<head>` of every page to enable feed readers to easily find the feed.
+
+You may also want to link to the feed within your site itself.

--- a/docs/feed.md
+++ b/docs/feed.md
@@ -16,16 +16,20 @@ To create a feed, add a file named `feed.njk` with the following content:
 eleventyExcludeFromCollections: true
 layout: feed
 permalink: /feed.xml
+pagination:
+  data: collections.post
+  size: 20
+  reverse: true
 ---
 ```
 
 The `permalink` value is the location of the generated feed.
 
-## Create a collection of posts
+## Create a collection of pages
 
-The feed will include all pages in a collection called 'post'.
+The feed will include all pages in the collection referenced by the `data` key of the `pagination` object.
 
-You can create this by adding some code to your `eleventy.config.js`:
+You can create a collection by adding some code to your `eleventy.config.js`:
 
 ```js
 eleventyConfig.addCollection('post', (collection) => {

--- a/docs/feed.njk
+++ b/docs/feed.njk
@@ -1,5 +1,0 @@
----
-eleventyExcludeFromCollections: true
-layout: feed
-permalink: /feed.xml
----

--- a/docs/feed.njk
+++ b/docs/feed.njk
@@ -1,0 +1,5 @@
+---
+eleventyExcludeFromCollections: true
+layout: feed
+permalink: /feed.xml
+---

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -23,7 +23,6 @@ module.exports = function (eleventyConfig) {
     url:
       process.env.GITHUB_ACTIONS &&
       'https://x-govuk.github.io/govuk-eleventy-plugin/',
-    feedUrl: 'https://x-govuk.github.io/govuk-eleventy-plugin/feed.xml',
     stylesheets: ['/assets/application.css'],
     header: {
       logotype: 'x-govuk',

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -1,9 +1,9 @@
 const process = require('node:process')
-const rssPlugin = require("@11ty/eleventy-plugin-rss");
+const rssPlugin = require('@11ty/eleventy-plugin-rss')
 
 module.exports = function (eleventyConfig) {
   // Plugins
-  eleventyConfig.addPlugin(rssPlugin);
+  eleventyConfig.addPlugin(rssPlugin)
 
   eleventyConfig.addPlugin(require('./index.js'), {
     icons: {

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -1,7 +1,10 @@
 const process = require('node:process')
+const rssPlugin = require("@11ty/eleventy-plugin-rss");
 
 module.exports = function (eleventyConfig) {
   // Plugins
+  eleventyConfig.addPlugin(rssPlugin);
+
   eleventyConfig.addPlugin(require('./index.js'), {
     icons: {
       mask: 'https://raw.githubusercontent.com/x-govuk/logo/main/images/x-govuk-mask-icon.svg?raw=true',
@@ -20,6 +23,7 @@ module.exports = function (eleventyConfig) {
     url:
       process.env.GITHUB_ACTIONS &&
       'https://x-govuk.github.io/govuk-eleventy-plugin/',
+    feedUrl: 'https://x-govuk.github.io/govuk-eleventy-plugin/feed.xml',
     stylesheets: ['/assets/application.css'],
     header: {
       logotype: 'x-govuk',

--- a/layouts/base.njk
+++ b/layouts/base.njk
@@ -45,6 +45,8 @@
   <link rel="stylesheet" href="{{ stylesheet | canonicalUrl }}">
   {% endfor %}
 
+  {% if options.feedUrl %}<link rel="alternate" type="application/atom+xml" href="{{ options.feedUrl }}" >{% endif %}
+
   {% if options.url %}<meta property="og:url" content="{{ page.url | canonicalUrl }}">{% endif %}
   <meta property="og:title" content="{{ title }}">
   {% if description %}<meta property="og:description" name="description" content="{{ description | markdown("inline") | striptags(true) }}">{% endif %}

--- a/layouts/feed.njk
+++ b/layouts/feed.njk
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xml:base="{{ options.url }}">
+  <title>{{ options.homeKey }}</title>
+  <link href="{{ permalink | absoluteUrl(options.url) }}" rel="self"/>
+  <link href="{{ options.url }}"/>
+  <updated>{{ collections.post | getNewestCollectionItemDate | dateToRfc3339 }}</updated>
+  <id>{{ options.url }}/</id>
+  {%- for post in collections.post | reverse %}
+  {%- set absolutePostUrl = post.url | absoluteUrl(options.url) %}
+  <entry>
+    <title>{{ post.data.title }}</title>
+    <link href="{{ absolutePostUrl }}"/>
+    <updated>{{ post.date | dateToRfc3339 }}</updated>
+    <id>{{ absolutePostUrl }}</id>
+    {% if post.data.authors %}
+      {% for author in post.data.authors %}
+        <author>
+          <name>{{ author.name }}</name>
+          {% if author.url %}<uri>{{ author.url }}</uri>{% endif %}
+        </author>
+      {% endfor %}
+    {% elif post.data.author %}
+      <author>
+        <name>{{ post.data.author.name }}</name>
+        {% if post.data.author.url %}<uri>{{ post.data.author.url }}</uri>{% endif %}
+      </author>
+    {% endif %}
+    <content xml:lang="{{ language or "en" }}" type="html">
+      <![CDATA[ {{ post.templateContent | htmlToAbsoluteUrls(absolutePostUrl) }} ]]>
+    </content>
+  </entry>
+  {%- endfor %}
+</feed>

--- a/layouts/feed.njk
+++ b/layouts/feed.njk
@@ -5,28 +5,28 @@
   <link href="{{ options.url }}"/>
   <updated>{{ collections.post | getNewestCollectionItemDate | dateToRfc3339 }}</updated>
   <id>{{ options.url }}/</id>
-  {%- for post in collections.post | reverse %}
-  {%- set absolutePostUrl = post.url | absoluteUrl(options.url) %}
+  {%- for item in pagination.items %}
+  {%- set absolutePostUrl = item.url | absoluteUrl(options.url) %}
   <entry>
-    <title>{{ post.data.title }}</title>
+    <title>{{ item.data.title }}</title>
     <link href="{{ absolutePostUrl }}"/>
-    <updated>{{ post.date | dateToRfc3339 }}</updated>
+    <updated>{{ item.date | dateToRfc3339 }}</updated>
     <id>{{ absolutePostUrl }}</id>
-    {% if post.data.authors %}
-      {% for author in post.data.authors %}
+    {% if item.data.authors %}
+      {% for author in item.data.authors %}
         <author>
           <name>{{ author.name }}</name>
           {% if author.url %}<uri>{{ author.url }}</uri>{% endif %}
         </author>
       {% endfor %}
-    {% elif post.data.author %}
+    {% elif item.data.author %}
       <author>
-        <name>{{ post.data.author.name }}</name>
-        {% if post.data.author.url %}<uri>{{ post.data.author.url }}</uri>{% endif %}
+        <name>{{ item.data.author.name }}</name>
+        {% if item.data.author.url %}<uri>{{ item.data.author.url }}</uri>{% endif %}
       </author>
     {% endif %}
     <content xml:lang="{{ language or "en" }}" type="html">
-      <![CDATA[ {{ post.templateContent | htmlToAbsoluteUrls(absolutePostUrl) }} ]]>
+      <![CDATA[ {{ item.templateContent | htmlToAbsoluteUrls(absolutePostUrl) }} ]]>
     </content>
   </entry>
   {%- endfor %}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@11ty/eleventy": "^2.0.0",
         "@11ty/eleventy-navigation": "^0.3.2",
+        "@11ty/eleventy-plugin-rss": "^1.2.0",
         "@rollup/plugin-commonjs": "^25.0.0",
         "@rollup/plugin-node-resolve": "^15.0.0",
         "@x-govuk/govuk-prototype-components": "^3.0.0",
@@ -147,6 +148,20 @@
       "integrity": "sha512-4aKW5aIQDFed8xs1G1pWcEiFPcDSwZtA4IH1eERtoJ+Xy+/fsoe0pzbDmw84bHZ9ACny5jblENhfZhcCxklqQw==",
       "dependencies": {
         "dependency-graph": "^0.11.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/11ty"
+      }
+    },
+    "node_modules/@11ty/eleventy-plugin-rss": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@11ty/eleventy-plugin-rss/-/eleventy-plugin-rss-1.2.0.tgz",
+      "integrity": "sha512-YzFnSH/5pObcFnqZ2sAQ782WmpOZHj1+xB9ydY/0j7BZ2jUNahn53VmwCB/sBRwXA/Fbwwj90q1MLo01Ru0UaQ==",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "posthtml": "^0.16.6",
+        "posthtml-urls": "1.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@x-govuk/govuk-eleventy-plugin",
-  "version": "6.0.5",
+  "version": "6.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@x-govuk/govuk-eleventy-plugin",
-      "version": "6.0.5",
+      "version": "6.1.0",
       "license": "MIT",
       "dependencies": {
         "@11ty/eleventy": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@x-govuk/govuk-eleventy-plugin",
-  "version": "6.0.5",
+  "version": "6.1.0",
   "description": "Write documentation using Markdown and publish it using GOV.UK styles",
   "keywords": [
     "govuk",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   "dependencies": {
     "@11ty/eleventy": "^2.0.0",
     "@11ty/eleventy-navigation": "^0.3.2",
+    "@11ty/eleventy-plugin-rss": "^1.2.0",
     "@rollup/plugin-commonjs": "^25.0.0",
     "@rollup/plugin-node-resolve": "^15.0.0",
     "@x-govuk/govuk-prototype-components": "^3.0.0",


### PR DESCRIPTION
Adds a new template for [Atom feeds](https://en.wikipedia.org/wiki/Atom_(web_standard)), allowing people to subscribe to receive content within a feed reader.