### PR TITLE
Improve documentation for collection pages

### DIFF
--- a/docs/layouts/collection.md
+++ b/docs/layouts/collection.md
@@ -6,15 +6,22 @@ description: Layout for a paginated list of pages.
 
 > View an <a href="/example-layouts/collection" target="_blank">example page that uses this layout (opens in a new tab)</a>
 
-To use this layout, make `collection` the value for a page’s `layout` key:
+To use this layout, make `collection` the value for a page’s `layout` key.
+
+You will also need to say which pages should be listed, by using the options under the `pagination` key:
 
 ```yaml
 ---
 layout: collection
 title: Page title
+paginationHeading: Posts
+pagination:
+  data: collections.post
+  size: 20
+  reverse: true
 ---
 
-Page content
+Page introduction content (optional).
 ```
 
 In addition to [common front matter options](/layouts#common-front-matter-options), this layout accepts the following options:
@@ -32,6 +39,21 @@ In addition to [common front matter options](/layouts#common-front-matter-option
       { text: "pagination" },
       { text: "object" },
       { text: "**Required.** Pages to show in the paginated list. Learn more about [pagination](https://www.11ty.dev/docs/pagination/) in the documentation for Eleventy." | markdown }
+    ],
+    [
+      { text: "pagination.data" },
+      { text: "string" },
+      { text: "The pages that should be listed, usually a reference to a [collection](https://www.11ty.dev/docs/collections/)" | markdown }
+    ],
+    [
+      { text: "pagination.size" },
+      { text: "number" },
+      { text: "The number of items to list" }
+    ],
+    [
+      { text: "pagination.reverse" },
+      { text: "boolean" },
+      { text: "Set to `true` to list the items in reverse date order" | markdown }
     ],
     [
       { text: "paginationHeading" },


### PR DESCRIPTION
I found this slightly confusing when setting up collection pages on a new site - mainly because the example doesn’t contain the required pagination options.

This updates this the example frontmatter, and lists some of the pagination options, as well as continuing to link out to the Eleventy documentation.