### PR TITLE
Fix: Escape double brackets in GitHub actions

### DIFF
--- a/docs/hosting.md
+++ b/docs/hosting.md
@@ -56,7 +56,7 @@ jobs:
   deploy:
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+      url: ${% raw %}{{ steps.deployment.outputs.page_url }}{% endraw %}
     runs-on: ubuntu-latest
     needs: build
     steps:


### PR DESCRIPTION
Currently it shows as `url: $` which then throws a warning when deploying:

> Environment URL '$' is not a valid http(s) URL, so it will not be shown as a link in the workflow graph.

This fixes the example by escaping the brackets so they are shown instead of being interpreted as Nunjucks.