### PR TITLE
Update GitHub actions versions

### DIFF
--- a/docs/hosting.md
+++ b/docs/hosting.md
@@ -43,15 +43,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Setup Pages
-      uses: actions/configure-pages@v2
+      uses: actions/configure-pages@v5
     - name: Install dependencies
       run: npm ci
     - name: Build with Eleventy
       run: npm run-script build
     - name: Upload artifact
-      uses: actions/upload-pages-artifact@v1
+      uses: actions/upload-pages-artifact@v3
 
   deploy:
     environment:
@@ -62,7 +62,7 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4
 ```
 
 Then, in your repository’s settings, under ‘Pages’, set ‘Source’ to ‘GitHub Actions’.


### PR DESCRIPTION
This avoids a bunch of deprecation warnings:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: