### PR TITLE
Use canonicalUrl filter in Atom feed

### DIFF
--- a/layouts/feed.njk
+++ b/layouts/feed.njk
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom" xml:base="{{ options.url }}">
   <title>{{ options.homeKey }}</title>
-  <link href="{{ permalink | absoluteUrl(options.url) }}" rel="self"/>
+  <link href="{{ permalink | canonicalUrl }}" rel="self"/>
   <link href="{{ options.url }}"/>
   <updated>{{ collections.post | getNewestCollectionItemDate | dateToRfc3339 }}</updated>
   <id>{{ options.url }}/</id>
   {%- for item in pagination.items %}
-  {%- set absolutePostUrl = item.url | absoluteUrl(options.url) %}
+  {%- set absolutePostUrl = item.url | canonicalUrl %}
   <entry>
     <title>{{ item.data.title }}</title>
     <link href="{{ absolutePostUrl }}"/>


### PR DESCRIPTION
Switching to using the custom `canonicalUrl` filter defined in this plugin rather than the `absoluteUrl` filter defined in the `eleventy-plugin-rss` plugin, so the URLs will include any `pathPrefix` defined in the Eleventy config.

This is because, I think, the two filters work in subtly different ways:

`absoluteUrl` [resolves a path with a base url](https://github.com/11ty/eleventy-plugin-rss/blob/master/src/absoluteUrl.js#L4-L12), which means that:

`'/path/test' | absoluteUrl('https://example.test/prefix')` returns `https://example.test/path/test` - as the initial `/` in the path indicates a root-relative url.

`canonicalUrl` [appends the paths together](https://github.com/x-govuk/govuk-eleventy-plugin/blob/main/lib/filters/canonical-url.js#L28), which means that:

`'/path/test' | canonicalUrl('https://example.test/prefix/')` returns `https://example.test/prefix/path/test`

An alternative solution would be to use the [`url` filter from Eleventy](https://www.11ty.dev/docs/filters/url/) or the [HTML base plugin](https://www.11ty.dev/docs/plugins/html-base/) included with Eleventy 2.0+ - however that one still wouldn't work on the Atom feed as it only transforms links in HTML automatically, and so we’d have to use the `htmlBaseUrl` filter instead. 🤯 