### PR TITLE
Remove SCSS files in all collection

### DIFF
--- a/docs/markdown-advanced.md
+++ b/docs/markdown-advanced.md
@@ -138,6 +138,7 @@ The rendered output looks like this:
 Here's a simple footnote,[^1] and here's a longer one.[^bignote]
 
 [^1]: This is the first footnote.
+
 [^bignote]: Here's one with multiple paragraphs and code.
 
     Indent paragraphs to include them in the footnote.

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ module.exports = function (eleventyConfig, pluginOptions = {}) {
   eleventyConfig.setLibrary('njk', require('./lib/nunjucks.js')(eleventyConfig))
 
   // Collections
+  eleventyConfig.addCollection('all', require('./lib/collections/all.js'))
   eleventyConfig.addCollection(
     'ordered',
     require('./lib/collections/ordered.js')

--- a/lib/collections/all.js
+++ b/lib/collections/all.js
@@ -1,0 +1,2 @@
+module.exports = (collection) =>
+  collection.getAll().filter((item) => !item.inputPath.includes('.scss'))


### PR DESCRIPTION
It’s possible to add a SCSS settings file, either in a custom location else defaulting to `sass/_settings.scss`.

This file gets imported at run time, and parsed by Dart Sass. For this reason, it’s not possible to remove this file from the `all` collection using the `eleventyExcludeFromCollections` front matter key, as that throws a Sass compilation error. 

This PR filters out any files that include `.scss` in their input path, and removes it from the `all` collection.