### PR TITLE
Fix `og:image` metadata duplication

### DIFF
--- a/docs/example-layouts/post.md
+++ b/docs/example-layouts/post.md
@@ -7,6 +7,7 @@ image:
   src: /assets/example-layouts/post-image.jpg
   alt: High angle photo of assorted-colour plastic balls.
   caption: Photo by [Greyson Joralemon](https://unsplash.com/@greysonjoralemon) on [Unsplash](https://unsplash.com/photos/9IBqihqhuHc)
+  opengraphImage: true
 authors:
   - name: Rod Gandini
     url: '#'

--- a/layouts/base.njk
+++ b/layouts/base.njk
@@ -3,9 +3,10 @@
 {% set assetUrl = assetPath | canonicalUrl %}
 {% set themeColor = options.themeColour %}
 
-{# Only show default Open Graph image if document does not provide its own #}
+{# Set the opengraphImageUrl in parent template to either the one
+   from the page metadata or else fallback to the generic one from options. #}
 {% set opengraphImage = image if image.opengraphImage else opengraphImage %}
-{% set opengraphImageUrl = options.opengraphImageUrl if not opengraphImage %}
+{% set opengraphImageUrl = (opengraphImage.src | canonicalUrl) if opengraphImage else options.opengraphImageUrl %}
 
 {# Pagination #}
 {% set pageNumber = pagination.pageNumber + 1 %}
@@ -52,7 +53,7 @@
   {% if description %}<meta property="og:description" name="description" content="{{ description | markdown("inline") | striptags(true) }}">{% endif %}
   {% if opengraphImage %}<meta name="twitter:card" content="summary_large_image">{% endif %}
   {% if opengraphImage.src %}<meta name="twitter:image" content="{{ opengraphImage.src | canonicalUrl }}">
-  <meta property="og:image" content="{{ opengraphImage.src | canonicalUrl }}">{% endif %}
+  {% endif %}
   {% if opengraphImage.alt %}<meta property="og:image:alt" content="{{ opengraphImage.alt }}">{% endif %}
 {% endblock %}
 


### PR DESCRIPTION
I couldn’t quite work out why the issue in #279 happens, as the existing logic in the template seems ok to me (if slightly confusing).

But I think this change will fix it, by always relying on the parent template to [set the opengraph image meta tag](https://github.com/alphagov/govuk-frontend/blob/main/packages/govuk-frontend/src/govuk/template.njk#L25) instead of including it within this base template and turning it off in the parent one...