### PR TITLE
Respect `nunjucksEnvironmentOptions`

### DIFF
--- a/lib/nunjucks.js
+++ b/lib/nunjucks.js
@@ -32,15 +32,22 @@ module.exports = (eleventyConfig) => {
     ...input
   ]
 
+  /**
+   * Set default options, but respect `nunjucksEnvironmentOptions`
+   * @see {@link https://www.11ty.dev/docs/languages/nunjucks/#optional-use-your-nunjucks-environment-options}
+   */
+  const options = {
+    autoescape: false,
+    lstripBlocks: true,
+    trimBlocks: true,
+    noCache: process.env === 'development',
+    watch: process.env === 'development',
+    ...eleventyConfig.nunjucksEnvironmentOptions
+  }
+
   const nunjucks = new Nunjucks.Environment(
     new Nunjucks.FileSystemLoader(searchPaths),
-    {
-      autoescape: false,
-      lstripBlocks: true,
-      trimBlocks: true,
-      noCache: process.env === 'development',
-      watch: process.env === 'development'
-    }
+    options
   )
 
   return nunjucks


### PR DESCRIPTION
If a user wishes to add their own Nunjucks environment options, Eleventy allows you to do this using [the `nunjucksEnvironmentOptions` option](nunjucksEnvironmentOptions).

Eleventy’s docs go on to note that, [using your own Nunjucks environment](https://www.11ty.dev/docs/languages/nunjucks/#advanced-use-your-nunjucks-environment) is not compatible with `setNunjucksEnvironmentOptions`.

As the plugin does configure a new Nunjucks environment, any `nunjucksEnvironmentOptions` will be ignored, but this is invisible to any consumer of the plugin.

However, we can respect `nunjucksEnvironmentOptions` by merging its values with the default options we’re setting.

Using the spread operator mostly works, although not with deeply nested properties. Nunjucks does have [one nested property, `web`](https://mozilla.github.io/nunjucks/api.html#configure), but it’s not relevant to how we are using it Nunjucks here, server-side, so setting those options would have no effect anyway.