### PR TITLE
Add `showBreadcrumbs` option

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -88,6 +88,11 @@ module.exports = function(eleventyConfig) {
       { text: "Path to SCSS file, relative to input directory, containing [GOV.UK Frontend settings](https://frontend.design-system.service.gov.uk/sass-api-reference/) (default is `{dir.input}/sass/_settings.scss`)." | markdown }
     ],
     [
+      { text: "showBreadcrumbs" },
+      { text: "boolean" },
+      { text: "Show breadcrumb navigation (default is `true` with nested pages)." | markdown }
+    ],
+    [
       { text: "stylesheets" },
       { text: "Array" },
       { text: "Additional stylesheets to load after application styles." }

--- a/layouts/base.njk
+++ b/layouts/base.njk
@@ -16,7 +16,7 @@
 {% set breadcrumbItems = collections.all | eleventyNavigationBreadcrumb(eleventyNavigation.key, { includeSelf: includeInBreadcrumbs }) | itemsFromNavigation(page.url, options) if eleventyNavigation.key %}
 {% set minimumItemsInBreadcrumbs = 0 %}
 {% set minimumItemsInBreadcrumbs = 1 if options.parentSite %}
-{% set showBreadcrumbs = breadcrumbItems | length > minimumItemsInBreadcrumbs %}
+{% set showBreadcrumbs = options.showBreadcrumbs and breadcrumbItems | length > minimumItemsInBreadcrumbs %}
 
 {# Components #}
 {% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}


### PR DESCRIPTION
Currently, we show breadcrumbs when EleventyNavigation reports that there are child pages. But they may not always be wanted, especially if you are showing primary/secondary navigation.

This PR adds a new `showBreadcrumbs` option. Setting this to `false` will disable breadcrumbs across an entire site.