### PR TITLE
Add `titleSuffix` as future replacement for `header.organisationName` option

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -103,6 +103,11 @@ module.exports = function(eleventyConfig) {
       { text: "Browser theme colour. Must be a hex value, i.e. `#0b0c0c`" | markdown }
     ],
     [
+      { text: "titleSuffix" },
+      { text: "string" },
+      { text: "Value to show at the end of the document title (default is `GOV.UK`)." | markdown }
+    ],
+    [
       { text: "url" },
       { text: "string" },
       { text: "The URL of your website. Optional, but required to have valid canonical URLs in Open Graph meta data." }

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -20,6 +20,7 @@ module.exports = function (eleventyConfig) {
       url: 'https://x-govuk.github.io/#projects',
       name: 'X-GOVUK projects'
     },
+    titleSuffix: 'X-GOVUK',
     url:
       process.env.GITHUB_ACTIONS &&
       'https://x-govuk.github.io/govuk-eleventy-plugin/',
@@ -27,7 +28,6 @@ module.exports = function (eleventyConfig) {
     header: {
       logotype: 'x-govuk',
       productName: 'Eleventy Plugin',
-      organisationName: 'X-GOVUK',
       search: {
         indexPath: '/search.json',
         sitemapPath: '/sitemap'

--- a/layouts/base.njk
+++ b/layouts/base.njk
@@ -61,8 +61,8 @@
   {{- title if title -}}
   {{- " (page " + pageNumber + " of " + pageCount + ")" if pageCount > 1 -}}
   {{- " - " + options.header.productName if options.header.productName -}}
-  {%- if options.organisationName or options.header.organisationName %}
-    {{- " - " + (options.organisationName if options.organisationName else options.header.organisationName) -}}
+  {%- if options.titleSuffix or options.header.organisationName %}
+    {{- " - " + (options.titleSuffix if options.titleSuffix else options.header.organisationName) -}}
   {%- endif %}
 {% endblock %}
 

--- a/layouts/base.njk
+++ b/layouts/base.njk
@@ -61,7 +61,9 @@
   {{- title if title -}}
   {{- " (page " + pageNumber + " of " + pageCount + ")" if pageCount > 1 -}}
   {{- " - " + options.header.productName if options.header.productName -}}
-  {{- " - " + options.header.organisationName -}}
+  {%- if options.organisationName or options.header.organisationName %}
+    {{- " - " + (options.organisationName if options.organisationName else options.header.organisationName) -}}
+  {%- endif %}
 {% endblock %}
 
 {% block header %}

--- a/lib/data/options.js
+++ b/lib/data/options.js
@@ -17,7 +17,7 @@ const defaultOptions = {
     copyright: 'crown', // Crown copyright
     licence: 'ogl' // Open Government Licence v3.0
   },
-  organisationName: 'GOV.UK',
+  titleSuffix: 'GOV.UK',
   header: {
     homepageUrl: '/',
     organisationLogo: 'crown',

--- a/lib/data/options.js
+++ b/lib/data/options.js
@@ -21,7 +21,7 @@ const defaultOptions = {
   header: {
     homepageUrl: '/',
     organisationLogo: 'crown',
-    organisationName: 'GOV.UK', // Deprecated: to be removed
+    organisationName: 'GOV.UK', // Deprecated: will be removed in v7.0
     productName: false
   },
   homeKey: 'Home',

--- a/lib/data/options.js
+++ b/lib/data/options.js
@@ -21,7 +21,7 @@ const defaultOptions = {
   header: {
     homepageUrl: '/',
     organisationLogo: 'crown',
-    organisationName: 'GOV.UK',  // Deprecated: to be removed
+    organisationName: 'GOV.UK', // Deprecated: to be removed
     productName: false
   },
   homeKey: 'Home',

--- a/lib/data/options.js
+++ b/lib/data/options.js
@@ -17,10 +17,11 @@ const defaultOptions = {
     copyright: 'crown', // Crown copyright
     licence: 'ogl' // Open Government Licence v3.0
   },
+  organisationName: 'GOV.UK',
   header: {
     homepageUrl: '/',
     organisationLogo: 'crown',
-    organisationName: 'GOV.UK',
+    organisationName: 'GOV.UK',  // Deprecated: to be removed
     productName: false
   },
   homeKey: 'Home',


### PR DESCRIPTION
This moves the organisationName config option out from the `header` config option to be a top-level config option named `titleSuffi`, as it is now only used in the title tag.

To avoid a breaking change, `header.organisationName` is still supported a fallback. This could be removed in a future breaking change release.

Additionally, if both `titleSuffix` and `header.organisationName` are set to `false`, then the `-` will not be added to the title tag (for scenarios where an title suffix might not be needed).