### PR TITLE
Allow `titleSuffix` option to accept boolean

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -104,7 +104,7 @@ module.exports = function(eleventyConfig) {
     ],
     [
       { text: "titleSuffix" },
-      { text: "string" },
+      { text: "string or boolean" },
       { text: "Value to show at the end of the document title (default is `GOV.UK`)." | markdown }
     ],
     [

--- a/layouts/base.njk
+++ b/layouts/base.njk
@@ -61,9 +61,7 @@
   {{- title if title -}}
   {{- " (page " + pageNumber + " of " + pageCount + ")" if pageCount > 1 -}}
   {{- " - " + options.header.productName if options.header.productName -}}
-  {%- if options.titleSuffix or options.header.organisationName %}
-    {{- " - " + (options.titleSuffix if options.titleSuffix else options.header.organisationName) -}}
-  {%- endif %}
+  {{- " - " + options.titleSuffix if options.titleSuffix -}}
 {% endblock %}
 
 {% block header %}

--- a/lib/data/options.js
+++ b/lib/data/options.js
@@ -17,22 +17,31 @@ const defaultOptions = {
     copyright: 'crown', // Crown copyright
     licence: 'ogl' // Open Government Licence v3.0
   },
-  titleSuffix: 'GOV.UK',
   header: {
     homepageUrl: '/',
-    organisationLogo: 'crown',
-    organisationName: 'GOV.UK', // Deprecated: will be removed in v7.0
     productName: false
   },
   homeKey: 'Home',
   parentSite: false,
   search: false,
   stylesheets: [],
+  titleSuffix: 'GOV.UK',
   url: false
 }
 
 module.exports = function (options, pathPrefix) {
   options.pathPrefix = pathPrefix
+
+  // Support former `header.organisationName` option
+  // Deprecated: will be removed in v7.0
+  if (options.header?.organisationName) {
+    options.titleSuffix = options.header.organisationName
+  }
+
+  // Let `true` mean the default title suffix (`true` is rendered as a string)
+  if (options.titleSuffix === true) {
+    delete options.titleSuffix
+  }
 
   return deepmerge(defaultOptions, options)
 }


### PR DESCRIPTION
Adds the option to set `titleSuffix` to `false`, which means no suffix is added to the document title.

As this option now accepts a boolean, and `true` gets rendered as `- true`, make it so that `true` means use the default value.