### PR TITLE
Remove `header.productName` from page title

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -16,11 +16,11 @@ module.exports = function (eleventyConfig) {
     opengraphImageUrl:
       'https://x-govuk.github.io/govuk-eleventy-plugin/assets/opengraph-image.png',
     homeKey: 'GOV.UK Eleventy Plugin',
+    titleSuffix: 'GOV.UK Eleventy Plugin',
     parentSite: {
       url: 'https://x-govuk.github.io/#projects',
       name: 'X-GOVUK projects'
     },
-    titleSuffix: 'X-GOVUK',
     url:
       process.env.GITHUB_ACTIONS &&
       'https://x-govuk.github.io/govuk-eleventy-plugin/',

--- a/layouts/base.njk
+++ b/layouts/base.njk
@@ -60,7 +60,6 @@
 {% block pageTitle %}
   {{- title if title -}}
   {{- " (page " + pageNumber + " of " + pageCount + ")" if pageCount > 1 -}}
-  {{- " - " + options.header.productName if options.header.productName -}}
   {{- " - " + options.titleSuffix if options.titleSuffix -}}
 {% endblock %}
 


### PR DESCRIPTION
Prevent `header.productName` from appearing in the page title. This is because:

- The option doesn’t indicate that this value will appear in the title
- The new `titleSuffix` option means you can add this information via that option