### PR TITLE
Add tags to conditionals for document header

### DIFF
--- a/components/document-header/template.njk
+++ b/components/document-header/template.njk
@@ -16,7 +16,7 @@
     </p>
   {% endif %}
 
-  {% if params.date or params.modified or params.authors or params.author %}
+  {% if params.date or params.modified or params.authors or params.author or params.tags   %}
     <p class="app-document-header__metadata">
       {%- if params.authors -%}
         <span class="govuk-visually-hidden">Posted by</span>


### PR DESCRIPTION
Couldn't get tags to show and realised it was because it's not declared in the setup. I think  params.tags will work but it may also need to be params.tags | length > 0