### PR TITLE
Add Google Tag Manager option

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -33,6 +33,11 @@ module.exports = function(eleventyConfig) {
   ],
   rows: [
     [
+      { text: "googleTagManagerIdentifier" },
+      { text: "string" },
+      { text: "The unique identifier within the Google Tag Manager snippet that follows `GTM-`" | markdown }
+    ],
+    [
       { text: "icons" },
       { text: "object" },
       { text: "Override GOV.UK icons." }

--- a/layouts/base.njk
+++ b/layouts/base.njk
@@ -41,6 +41,15 @@
 {% endblock %}
 
 {% block head %}
+  {% if options.googleTagManagerIdentifier %}
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-{{ options.googleTagManagerIdentifier }}');</script>
+    <!-- End Google Tag Manager -->
+  {% endif %}
   <link rel="stylesheet" href="{{ "/assets/govuk.css" | canonicalUrl }}">
   {% for stylesheet in options.stylesheets %}
   <link rel="stylesheet" href="{{ stylesheet | canonicalUrl }}">
@@ -73,6 +82,15 @@
 
 {% block footer %}
   {{ appFooter(options.footer) }}
+{% endblock %}
+
+{% block bodyStart %}
+  {% if options.googleTagManagerIdentifier %}
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-{{ options.googleTagManagerIdentifier }}"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
+  {% endif %}
 {% endblock %}
 
 {% block bodyEnd %}


### PR DESCRIPTION
This is a proposal to add Google Tag Manager to XGOV's  Eleventy plugin.

This requires updating the `base.njk` layout by adding a conditional statement on whether a Google Tag Manager identifier is added via `eleventy.config.js` file.