### PR TITLE
Allow copyright and content licence to be removed

### DIFF
--- a/components/footer/template.njk
+++ b/components/footer/template.njk
@@ -53,20 +53,22 @@
           <span class="govuk-footer__licence-description">
             {{ params.contentLicence.html | safe if params.contentLicence.html else params.contentLicence.text }}
           </span>
-        {% else %}
+        {% elseif params.contentLicence != false %}
           {% include "./_ogl.svg" %}
           <span class="govuk-footer__licence-description">
             All content is available under the <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated
           </span>
         {% endif %}
       </div>
-      <div class="govuk-footer__meta-item">
-      {%- if params.copyright.html or params.copyright.text -%}
-        {{ params.copyright.html | safe if params.copyright.html else params.copyright.text }}
-      {% else %}
-        <a class="govuk-footer__link govuk-footer__copyright-logo" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">©&nbsp;Crown copyright</a>
+      {%- if params.copyright != false -%}
+        <div class="govuk-footer__meta-item">
+          {%- if params.copyright.html or params.copyright.text -%}
+            {{ params.copyright.html | safe if params.copyright.html else params.copyright.text }}
+          {% else %}
+            <a class="govuk-footer__link govuk-footer__copyright-logo" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">©&nbsp;Crown copyright</a>
+          {% endif %}
+        </div>
       {% endif %}
-      </div>
     </div>
   </div>
 </footer>

--- a/docs/options.md
+++ b/docs/options.md
@@ -243,7 +243,7 @@ In addition to the [options available for the footer component](https://design-s
     [
       { text: "contentLicence" },
       { text: "object" },
-      { text: "Licence description. If no value is provided, the OGL logo is shown alongside the words `All content is available under the Open Government Licence v3.0, except where otherwise stated`." | markdown }
+      { text: "Licence description. If no value is provided, the OGL logo is shown alongside the words `All content is available under the Open Government Licence v3.0, except where otherwise stated`. Set to `false` to remove completely." | markdown }
     ],
     [
       { text: "contentLicence.text" },
@@ -258,7 +258,7 @@ In addition to the [options available for the footer component](https://design-s
     [
       { text: "copyright" },
       { text: "object" },
-      { text: "Copyright statement. If no value is provided, `© Crown copyright` is displayed below an image of the Royal Coat of Arms." | markdown }
+      { text: "Copyright statement. If no value is provided, `© Crown copyright` is displayed below an image of the Royal Coat of Arms.  Set to `false` to remove completely." | markdown }
     ],
     [
       { text: "copyright.text" },


### PR DESCRIPTION
This lets you removes the copyright and content licence options from the footer entirely, by setting them to `false`. (Currently if you do that you get the default options).

Probably not that common a requirement, but feels like it ought to be possible to have a really minimal footer if you wanted to.