### PR TITLE
Allow missing breadcrumb navigation items

### DIFF
--- a/layouts/base.njk
+++ b/layouts/base.njk
@@ -13,7 +13,7 @@
 {% set pageCount = pagination.pages | length %}
 
 {# Navigation #}
-{% set breadcrumbItems = collections.all | eleventyNavigationBreadcrumb(eleventyNavigation.key, { includeSelf: includeInBreadcrumbs }) | itemsFromNavigation(page.url, options) if eleventyNavigation.key %}
+{% set breadcrumbItems = collections.all | eleventyNavigationBreadcrumb(eleventyNavigation.key, { includeSelf: includeInBreadcrumbs, allowMissing: true }) | itemsFromNavigation(page.url, options) if eleventyNavigation.key %}
 {% set minimumItemsInBreadcrumbs = 0 %}
 {% set minimumItemsInBreadcrumbs = 1 if options.parentSite %}
 {% set showBreadcrumbs = options.showBreadcrumbs != false and breadcrumbItems | length > minimumItemsInBreadcrumbs %}


### PR DESCRIPTION
When the `eleventyExcludeFromCollections` option is enabled, the `collections.all` array will not contain all pages, resulting in `eleventyNavigationBreadcrumb()` throwing a "Node does not exist" exception, which manifests as an opaque nunjucks error that is difficult for the reader to trace.

This change uses the `allowMissing` option of `eleventyNavigationBreadcrumb()` to effectively allow this scenario to fail silently (no breadcrumb will appear at all rather than failing to compile).

In our case, we use `eleventyExcludeFromCollections` to exclude some dynamically generated pages from `collections.all` for performance reasons.

We're using 11ty v3.0.0, but `allowMissing` is a valid option for `eleventyNavigation@0.3.5`.

@paulrobertlloyd I figured this would be a relatively safe option to hardcode into the base template, but do you think it warrants exposing as an option to consumers of this plugin?