### PR TITLE
Change precedence of Nunjucks searchPaths

### DIFF
--- a/lib/nunjucks.js
+++ b/lib/nunjucks.js
@@ -27,15 +27,13 @@ module.exports = (eleventyConfig) => {
   const { includes, input, layouts } = eleventyConfig.dir
 
   const searchPaths = [
-    './node_modules/@x-govuk/govuk-eleventy-plugin',
-    './node_modules/govuk-frontend/dist',
-    resolveNpmModule('@x-govuk/govuk-prototype-components'),
     ...(includes ? [path.join(input, includes)] : []),
     ...(layouts ? [path.join(input, layouts)] : []),
-    input
+    input,
+    './node_modules/@x-govuk/govuk-eleventy-plugin',
+    './node_modules/govuk-frontend/dist',
+    resolveNpmModule('@x-govuk/govuk-prototype-components')
   ]
-
-  console.log(searchPaths)
 
   /**
    * Set default options, but respect `nunjucksEnvironmentOptions`


### PR DESCRIPTION
Fixes #345.

Nunjucks’ `FileSystemLoader` takes the first matching directory when looking at `searchPaths`. Changing the order means an author can override inherited macros, filters and globals within their own app.