### PR TITLE
refactor: use absolute nunjucks import path

### DIFF
--- a/components/header/template.njk
+++ b/components/header/template.njk
@@ -1,4 +1,4 @@
-{%- from "../site-search/macro.njk" import appSiteSearch -%}
+{%- from "components/site-search/macro.njk" import appSiteSearch -%}
 {%- if options.navigation -%}
   {%- set headerClasses = " govuk-header--full-width-border" -%}
 {% elif layout == "product" or layout == "collection" %}


### PR DESCRIPTION
The "header" component macro currently imports the "site-search" macro using a relative URL. This prevents customisation of the "site-search" macro using the Nunjucks import prioritisation logic. Bringing this import inline with other import syntax across the plugin fixes this issue.

For example, a consuming 11ty app wants to override the site-search macro, so can now create a "_includes/components/site-search/macro.njk" template to do that.