### PR TITLE
Allow icons to be omitted by setting false

### DIFF
--- a/layouts/base.njk
+++ b/layouts/base.njk
@@ -35,9 +35,9 @@
 {% from "components/prose-scope/macro.njk" import appProseScope %}
 
 {% block headIcons %}
-  <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="{{ options.icons.shortcut }}" type="image/x-icon">
-  <link rel="mask-icon" href="{{ options.icons.mask }}" color="{{ themeColor }}">
-  <link rel="apple-touch-icon" href="{{ options.icons.touch }}">
+  {%- if options.icons.shortcut %}<link rel="shortcut icon" sizes="16x16 32x32 48x48" href="{{ options.icons.shortcut }}" type="image/x-icon">{% endif %}
+  {%- if options.icons.mask %}<link rel="mask-icon" href="{{ options.icons.mask }}" color="{{ themeColor }}">{% endif %}
+  {%- if options.icons.touch %}<link rel="apple-touch-icon" href="{{ options.icons.touch }}">{% endif %}
 {% endblock %}
 
 {% block head %}


### PR DESCRIPTION
If you don't want to use the default GOVUK icons but don't want to create your own (particularly the `.ico` format one), you should be able to turn them off by setting them to `false`:

```js
icons: {
  mask: false,
  shortcut: false,
  touch: false        
}
```

Not sure this needs to be advertised in the docs, as the plugin is mainly designed to be used for sites that do carry the govuk branding.