### PR TITLE
Remove non-alphanumeric characters from heading anchor IDs

### DIFF
--- a/lib/markdown-it.js
+++ b/lib/markdown-it.js
@@ -1,3 +1,4 @@
+const slugify = require('@sindresorhus/slugify')
 const MarkdownIt = require('markdown-it')
 const anchor = require('markdown-it-anchor')
 
@@ -29,7 +30,8 @@ module.exports = (options = {}) => {
             class: 'app-link--heading',
             safariReaderFix: true
           })
-        : false
+        : false,
+      slugify: (string) => slugify(string).replaceAll(/[*+~.()'"!:@]/g, '')
     })
     .use(require('markdown-it-deflist'))
     .use(require('./markdown-it/deflist.js'))


### PR DESCRIPTION
A heading with non-alphanumeric characters would show those characters in the `id`, used to link to sections of a page.

This PR runs the built-in slugger on heading anchors, then removes [*+~.()'"!:@] characters.

Fixes #369.