### PR TITLE
Fix broken github link by replacing git+ with an empty string

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -25,6 +25,6 @@ eleventyComputed:
     <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--xl govuk-!-margin-top-0">
     <h2 class="govuk-heading-m">Contribute</h2>
     <p class="govuk-body">The project repository is public and we welcome contributions from anyone.</p>
-    <p class="govuk-body"><a class="govuk-link govuk-link--no-visited-state" href="{{ pkg.repository.url | replace(".git", "") }}">View this project on GitHub</a></p>
+    <p class="govuk-body"><a class="govuk-link govuk-link--no-visited-state" href="{{ pkg.repository.url | replace(".git", "") | replace("git+","") }}">View this project on GitHub</a></p>
   </section>
 </div>


### PR DESCRIPTION
View this project on Github in the `index.md` file did not remove the `git+` from the repository url. I added another replace filter so the link works!