### PR TITLE
Markdown it customisation hooks

### DIFF
--- a/docs/markdown-advanced.md
+++ b/docs/markdown-advanced.md
@@ -8,6 +8,8 @@ related:
     - items:
       - text: Markdown Guide
         href: https://www.markdownguide.org
+      - text: Options for customising markdown parsing
+        href: ../options/#markdown-it-options
 ---
 
 [[toc]]

--- a/docs/options.md
+++ b/docs/options.md
@@ -131,6 +131,11 @@ export default function(eleventyConfig) {
       { text: "footer" },
       { text: "object" },
       { text: "See [footer options](#footer-options)." | markdown }
+    ],
+    [
+      { text: "markdownIt" },
+      { text: "object" },
+      { text: "See [markdown-it options](#markdown-it-options)." | markdown }
     ]
   ]
 }) }}
@@ -268,6 +273,31 @@ Alongside [options available for the footer component](https://design-system.ser
       { text: "logo" },
       { text: "boolean" },
       { text: "Show logo in rebranded footer (default is `true`)." | markdown }
+    ]
+  ]
+}) }}
+
+## markdown-it options
+
+The following options can be used to customise the markdown-it parser:
+
+{{ govukTable({
+  firstCellIsHeader: true,
+  head: [
+    { text: "Name" },
+    { text: "Type" },
+    { text: "Description" }
+  ],
+  rows: [
+    [
+      { text: "options" },
+      { text: "object" },
+      { text: "Override the default configuration options when initialising the markdown it options. See [markdown-it documentation](https://markdown-it.github.io/markdown-it/#MarkdownIt.new) for the available options." | markdown }
+    ],
+    [
+      { text: "configure" },
+      { text: "function" },
+      { text: "This will be passed the initialised markdown-it parser instance, e.g. to configure additional plugins. e.g.\n\n```javascript\n{\n    markdownIt: {\n        configure(md) {\n            md.use(myPlugin)\n        }\n    }\n}\n```" | markdown }
     ]
   ]
 }) }}

--- a/src/markdown-it.js
+++ b/src/markdown-it.js
@@ -31,7 +31,8 @@ export function md(options = {}) {
     highlight,
     html: true,
     linkify: false,
-    typographer: true
+    typographer: true,
+    ...(options?.markdownIt?.options ?? {})
   }
 
   const md = new MarkdownIt(opts)
@@ -72,6 +73,10 @@ export function md(options = {}) {
         return '</nav>'
       }
     })
+
+  if(options?.markdownIt?.configure) {
+    options.markdownIt.configure(md);
+  }
 
   return md
 }

--- a/test/markdown-it.js
+++ b/test/markdown-it.js
@@ -14,6 +14,26 @@ describe('markdown-it', () => {
     assert.equal(options.typographer, true)
   })
 
+  it('Uses provided configuration overrides', () => {
+    const pluginOptions = {
+      markdownIt: {
+        options: {
+          breaks: false,
+          langPrefix: 'lang-'
+        }
+      }
+    }
+
+    const { options } = md(pluginOptions)
+
+    assert.equal(options.breaks, false)
+    assert.equal(typeof options.highlight, 'function')
+    assert.equal(options.html, true)
+    assert.equal(options.linkify, false)
+    assert.equal(options.typographer, true)
+    assert.equal(options.langPrefix, 'lang-')
+  })
+
   it('Renders anchor heading permalinks when option enabled', () => {
     const result = md({ headingPermalinks: true }).render('# Heading')
 
@@ -53,5 +73,23 @@ describe('markdown-it', () => {
     const result = md().render('|A|B|\n|-|-|\n|1|2|')
 
     assert.match(result, /<table tabindex="0"/)
+  })
+
+  it('Allows configuring additional plugins', () => {
+    const plugin = (md) => {
+      const { rules } = md.renderer
+      rules.dl_open = () => '<dl class="govuk-summary-list">\n'
+    }
+
+    const options = {
+      markdownIt: {
+        configure(md) {
+          md.use(plugin)
+        }
+      }
+    }
+    const result = md(options).render('Term\n: Definition')
+
+    assert.match(result, /<dl class="govuk-summary-list"/)
   })
 })


### PR DESCRIPTION
Implementation for https://github.com/x-govuk/govuk-eleventy-plugin/issues/387

Adds ability to customise the markdown-it parser, either by providing overides for the initialisation options, or providing a customise function that is passed the parser instance, e.g. to use an additional plugin. 