### PR TITLE
feat: option to utilise markdown header as page title

### DIFF
--- a/docs/get-started/options.md
+++ b/docs/get-started/options.md
@@ -112,6 +112,11 @@ export default function(eleventyConfig) {
       { text: "Show breadcrumb navigation (default is `true` with nested pages)" | markdown }
     ],
     [
+      { text: "useMarkdownHeaderAsTitle" },
+      { text: "boolean" },
+      { text: "Use markdown header for page title (default is `false`). Useful for pages which use the following layouts: `page` and `page with sub navigation` where your markdown page might naturally use markdown h1 headings." | markdown }
+    ],
+    [
       { text: "stylesheets" },
       { text: "Array" },
       { text: "Stylesheets to load after application styles" }

--- a/example.config.js
+++ b/example.config.js
@@ -21,7 +21,8 @@ export default function (eleventyConfig) {
           }
         ]
       }
-    }
+    },
+    useMarkdownHeaderAsTitle: true,
   })
 
   // Passthrough

--- a/example/page.md
+++ b/example/page.md
@@ -1,7 +1,6 @@
 ---
 layout: page
 caption: Get started
-title: About this API
 description: The Apply for a juggling licence REST API is designed to make interacting with the licencing server quick and easy.
 order: 1
 related:
@@ -22,6 +21,7 @@ eleventyComputed:
     content: |
       This is an example page using the `page` layout. You can [view the source used to create this page on GitHub]({{ viewSource }}).
 ---
+# About this API
 
 Once a juggler has submitted their application via the Apply service, the application will become available over the API.
 

--- a/src/data/eleventy-computed.js
+++ b/src/data/eleventy-computed.js
@@ -1,4 +1,4 @@
-import { getNavigationKey, getNavigationParent } from '../utils.js'
+import { getTitle, getNavigationKey, getNavigationParent } from '../utils.js'
 
 /**
  * Set sensible defaults for eleventyNavigation
@@ -6,6 +6,7 @@ import { getNavigationKey, getNavigationParent } from '../utils.js'
  * @see {@link https://www.11ty.dev/docs/plugins/navigation/}
  */
 export const eleventyComputed = {
+  title: (data) => getTitle(data),
   eleventyNavigation: {
     key: (data) => getNavigationKey(data),
     parent: (data) => getNavigationParent(data),

--- a/src/data/options.js
+++ b/src/data/options.js
@@ -19,7 +19,8 @@ const defaults = {
   rebrand: true,
   stylesheets: [],
   titleSuffix: 'GOV.UK',
-  url: false
+  url: false,
+  useMarkdownHeaderAsTitle: false,
 }
 
 export function defaultPluginOptions(options, pathPrefix) {

--- a/src/layouts/base.njk
+++ b/src/layouts/base.njk
@@ -11,6 +11,7 @@
     from the page metadata or else fallback to the generic one from options. -#}
 {% set opengraphImage = image if image.opengraphImage else opengraphImage %}
 {% set opengraphImageUrl = (opengraphImage.src | canonicalUrl) if opengraphImage else options.opengraphImageUrl %}
+{% set useMarkdownHeaderAsTitle = useMarkdownHeaderAsTitle | default(options.useMarkdownHeaderAsTitle) %}
 
 {# Pagination #}
 {% set pageNumber = pagination.pageNumber + 1 %}

--- a/src/markdown-it.js
+++ b/src/markdown-it.js
@@ -17,6 +17,7 @@ import markdownItTableOfContents from 'markdown-it-table-of-contents'
 import { defListRules } from './markdown-it/deflist.js'
 import { footnotesRules } from './markdown-it/footnote.js'
 import { tableRules } from './markdown-it/table.js'
+import { headingRules } from './markdown-it/heading.js'
 
 /**
  * Configure markdown-it
@@ -72,6 +73,7 @@ export function md(options = {}) {
         return '</nav>'
       }
     })
+    .use(headingRules)
 
   return md
 }

--- a/src/markdown-it/heading.js
+++ b/src/markdown-it/heading.js
@@ -1,0 +1,46 @@
+/**
+ * Heading rules for markdown-it
+ * 
+ * @param {Function} md - markdown-it instance
+ */
+export function headingRules(md) {
+  const { rules } = md.renderer
+  const defaultOpenRenderer =
+    rules.heading_open ||
+    function (tokens, idx, options, env, self) {
+      return self.renderToken(tokens, idx, options)
+    }
+  const defaultCloseRenderer =
+    rules.heading_close ||
+    function (tokens, idx, options, env, self) {
+      return self.renderToken(tokens, idx, options)
+    }
+
+  rules.heading_open = (tokens, idx, options, env, self) => {
+    const useMarkdownHeaderAsTitle
+      = env.useMarkdownHeaderAsTitle // page front matter
+      ?? env?.options?.useMarkdownHeaderAsTitle // global options
+      ?? false; // default to false
+
+    if (tokens[idx].tag === 'h1' && useMarkdownHeaderAsTitle === true) {
+      tokens[idx + 1].children = []
+      return '';
+    }
+
+    return defaultOpenRenderer(tokens, idx, options, env, self)
+  }
+
+  // Also override heading_close to skip closing tag if we skipped opening
+  rules.heading_close = function (tokens, idx, options, env, self) {
+    const useMarkdownHeaderAsTitle
+      = env.useMarkdownHeaderAsTitle // page front matter
+      ?? env?.options?.useMarkdownHeaderAsTitle // global options
+      ?? false; // default to false
+
+    if (tokens[idx].tag === 'h1' && useMarkdownHeaderAsTitle === true) {
+      return '';
+    }
+
+    return defaultCloseRenderer(tokens, idx, options, env, self)
+  };
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,9 @@
 import fs from 'node:fs/promises'
 import path from 'node:path'
+import markdownit from 'markdown-it';
+
+// avoid new instance of MarkdownIt for each call
+const md = new markdownit();
 
 /**
  * Get file contents
@@ -102,4 +106,66 @@ export function normalise(value, defaultValue) {
   }
 
   return value
+}
+
+/**
+ * Extract the title from the page markdown h1.
+ * 
+ * @param {string} markdown - The page markdown content.
+ * @returns {string|null} - The extracted title or null.
+ */
+const extractTitleFromMarkdown = (markdown) => {
+  const tokens = md.parse(markdown, {});
+
+  for (const [i, { type, tag }] of tokens.entries()) {
+    if (type === 'heading_open' && tag === 'h1') {
+      // The next token should be the inline content of the heading
+      const contentTokens = tokens[i + 1];
+
+      let title = contentTokens.content
+
+      if (contentTokens.children) {
+        // Children array: filter for text and code_inline only
+        title = contentTokens.children
+          .filter(t => t.type === 'text' || t.type === 'code_inline')
+          .map(t => t.content)
+          .join('');
+      }
+
+      return title;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Get the page title from markdown h1 if configured and
+ * no explicit front matter title if provided.
+ * 
+ * @param {object} data - Page data
+ * @returns {string|null} - The default title or null.
+ */
+export const getTitle = (data) => {
+  const { eleventyExcludeFromCollections, options, title, page } = data;
+
+  const useMarkdownHeaderAsTitle
+    = data.useMarkdownHeaderAsTitle // page front matter
+    ?? options?.useMarkdownHeaderAsTitle // global options
+    ?? false;
+
+  if (!eleventyExcludeFromCollections) {
+
+    if (!useMarkdownHeaderAsTitle) {
+      return title;
+    }
+
+    // If title has explicitly set, regardless of useMarkdownHeaderAsTitle == true
+    // return it, enables pages to have a title explicitly set in front matter
+    if (![null, "", undefined].includes(title?.trim())) {
+      return title;
+    }
+
+    return extractTitleFromMarkdown(page?.rawInput);
+  }
 }

--- a/test/markdown-it.js
+++ b/test/markdown-it.js
@@ -54,4 +54,52 @@ describe('markdown-it', () => {
 
     assert.match(result, /<table tabindex="0"/)
   })
+
+  it('Does not render headings if options.useMarkdownHeaderAsTitle is true', () => {
+    // arrange
+    const options = { useMarkdownHeaderAsTitle: true } // global options
+    const frontMatter = { options } // page front matter
+
+    // act
+    const result = md().render('# Heading', frontMatter)
+
+    // assert
+    assert.equal(result, '')
+  })
+
+  it('Renders headings if options.useMarkdownHeaderAsTitle is false', () => {
+    // arrange
+    const options = { useMarkdownHeaderAsTitle: false } // global options
+    const frontMatter = { options } // page front matter
+
+    // act
+    const result = md().render('# Heading', frontMatter)
+
+    // assert
+    assert.match(result, /<h1 id="heading" tabindex="-1" class="govuk-heading-xl"\>Heading/)
+  })
+
+  it('Renders headings if front matter useMarkdownHeaderAsTitle is false', () => {
+    // arrange
+    const options = { useMarkdownHeaderAsTitle: true } // global options
+    const frontMatter = { options,  useMarkdownHeaderAsTitle: false } // page front matter
+
+    // act
+    const result = md().render('# Heading', frontMatter)
+
+    // assert
+    assert.match(result, /<h1 id="heading" tabindex="-1" class="govuk-heading-xl"\>Heading/)
+  })
+
+  it('Does not render headings if front matter useMarkdownHeaderAsTitle is true', () => {
+    // arrange
+    const options = { useMarkdownHeaderAsTitle: false } // global options
+    const frontMatter = { options, useMarkdownHeaderAsTitle: true } // page front matter
+
+    //act 
+    const result = md().render('# Heading', frontMatter)
+
+    // assert
+    assert.equal(result, '')
+  })
 })

--- a/test/utils.js
+++ b/test/utils.js
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict'
 import fs from 'node:fs/promises'
 import { describe, it } from 'node:test'
 
-import { getFileContents, getTemplates, normalise } from '../src/utils.js'
+import { getFileContents, getTemplates, normalise, getTitle } from '../src/utils.js'
 
 describe('getFileContents utility', () => {
   it('Gets file contents', async (t) => {
@@ -79,5 +79,84 @@ describe('normalise utility', () => {
 
     assert.equal(usesValue, 'Dollars')
     assert.equal(usesDefault, 'Pounds')
+  })
+})
+
+describe('getTitle utility', () => {
+  it('Returns the extracted title from markdown', () => {
+    // arrange
+    const data = { page: { rawInput: '# Test Title' }, options: { useMarkdownHeaderAsTitle: true } }
+
+    //act
+    const result = getTitle(data)
+
+    // assert
+    assert.equal(result, 'Test Title')
+  })
+
+  it('Returns the extracted title from markdown regardless of additional text formatting', () => {
+    // arrange
+    const data = { page: { rawInput: '# Test Title **bold** `stuff`' }, options: { useMarkdownHeaderAsTitle: true } }
+
+    // act
+    const result = getTitle(data)
+
+    // assert
+    assert.equal(result, 'Test Title bold stuff')
+  })
+
+  it('Returns explicit title if provided and options.useMarkdownHeaderAsTitle is true', () => {
+    // arrange
+    const data = { title: 'Explicit Title', page: { rawInput: '# Test Title' }, options: { useMarkdownHeaderAsTitle: true } }
+
+    // act
+    const result = getTitle(data)
+
+    // assert
+    assert.equal(result, 'Explicit Title')
+  })
+
+  it('Returns explicit title if provided and options.useMarkdownHeaderAsTitle is false', () => {
+    // arrange
+    const data = { title: 'Explicit Title', page: { rawInput: '# Test Title' }, options: { useMarkdownHeaderAsTitle: false } }
+
+    // act
+    const result = getTitle(data)
+
+    // assert
+    assert.equal(result, 'Explicit Title')
+  })
+
+  it('Returns null if no title can be extracted', () => {
+    // arrange
+    const data = { page: { rawInput: '' }, options: { useMarkdownHeaderAsTitle: true } }
+
+    // act
+    const result = getTitle(data)
+
+    // assert
+    assert.equal(result, null)
+  })
+
+  it('Returns undefined if eleventyExcludeFromCollections is true', () => {
+    // arrange
+    const data = { eleventyExcludeFromCollections: true, page: { rawInput: '# Test Title' }, options: { useMarkdownHeaderAsTitle: true } }
+
+    // act
+    const result = getTitle(data)
+
+    // assert
+    assert.equal(result, undefined)
+  })
+
+  it('Returns undefined if options.useMarkdownHeaderAsTitle is false and no title is explicitly set', () => {
+    // arrange
+    const data = { page: { rawInput: '# Test Title' }, options: { useMarkdownHeaderAsTitle: false } }
+
+    // act
+    const result = getTitle(data)
+
+    // assert
+    assert.equal(result, undefined)
   })
 })


### PR DESCRIPTION
@paulrobertlloyd

### Feature
Add option to take markdown headers and use them as the front matter title.

### Benefits
If you already have a lot of markdown content which utilise markdown headers i.e. `# Markdown Header` then you don't have to move it to front matter which might cause your markdown linter to complain.

### Detail
New plugin option called `useMarkdownHeaderAsTitle` added with default value as false so we don't break existing installs, this can be overridden using front matter.

Functionality is achieved utilising global `eleventyComputed` and existing dependencies markdown-it.
