### PR TITLE
Ensure SCSS `$govuk-assets-path` uses configured `pathPrefix`

### DIFF
--- a/src/application.scss
+++ b/src/application.scss
@@ -1,5 +1,7 @@
 // Use GOV.UK Frontend
 @use "pkg:govuk-frontend/dist/govuk" with (
+  // pathPrefix gets prepended to assets path in `generate-govuk-assets.js`
+  $govuk-assets-path: "/assets/",
   $govuk-global-styles: true,
   $govuk-new-organisation-colours: true,
   $govuk-new-typography-scale: true

--- a/src/events/generate-govuk-assets.js
+++ b/src/events/generate-govuk-assets.js
@@ -19,11 +19,21 @@ export async function generateAssets(dir, options) {
   // Ignored if custom stylesheets are used
   if (options.stylesheets.length === 0) {
     const inputFilePath = path.join(import.meta.dirname, '../application.scss')
-    const inputFile = await fs.readFile(inputFilePath)
+    let inputFile = await fs.readFile(inputFilePath)
+
+    // Update asset path to use configured path prefix
+    const assetPath = path.join(options.pathPrefix, '/assets/')
+    inputFile = inputFile
+      .toString()
+      .replace(
+        `$govuk-assets-path: "/assets/"`,
+        `$govuk-assets-path: "${assetPath}"`
+      )
+
     const outputFile = `${dir.output}/assets/application.css`
 
     try {
-      const result = sass.compileString(inputFile.toString(), {
+      const result = sass.compileString(inputFile, {
         importers: [new sass.NodePackageImporter()], // Imports with `pkg:`
         loadPaths: ['./node_modules', '.'], // Imports without `pkg:`
         quietDeps: true,


### PR DESCRIPTION
Fixes #394.

This only updates `$govuk-assets-path` for the default stylesheet; if a user is using their own stylesheet(s), they can configure this setting themselves, however they see fit.