### PR TITLE
Add support for Markdown alerts

### DIFF
--- a/example/markdown.md
+++ b/example/markdown.md
@@ -95,19 +95,57 @@ The rendered output looks like this:
 >
 > > Indeed, it has been said that democracy is the worst form of government except all those other forms that have been tried from time to time.
 
-### Blockquotes with other elements
+## Alerts
 
-Blockquotes can contain other Markdown formatted elements. Not all elements can be used — you’ll need to experiment to see which ones work.
+Alerts, based on the blockquote syntax, can be used emphasise critical information. [On GitHub they are displayed with distinctive colors and icons](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts), while pages rendered by the plugin use the [inset text component](https://design-system.service.gov.uk/components/inset-text/) from the GOV.UK Design System.
 
 ```markdown
-> #### Check the MOT status of a vehicle
+> [!NOTE]
+> Highlights information that users should take into account, even when skimming.
+
+> [!TIP]
+> Optional information to help a user be more successful.
+
+> [!IMPORTANT]
+> Key information users need to know to achieve their goal.
+
+> [!WARNING]
+> Urgent info that needs immediate user attention to avoid problems.
+
+> [!CAUTION]
+> Advises about risks or negative outcomes of certain actions.
+```
+
+The rendered output for the note alert type uses the standard design for inset text:
+
+> [!NOTE]
+> Highlights information that users should take into account, even when skimming.
+
+The rendered output for other alert types uses inset text with a coloured border and background:
+
+> [!TIP]
+> Optional information to help a user be more successful.
+
+> [!IMPORTANT]
+> Key information users need to know to achieve their goal.
+
+> [!WARNING]
+> Urgent info that needs immediate user attention to avoid problems.
+
+> [!CAUTION]
+> Advises about risks or negative outcomes of certain actions.
+
+You can also include a title:
+
+```markdown
+> [!NOTE] Check the MOT status of a vehicle
 >
 > If your vehicle is new, you must [get an MOT test](https://www.gov.uk/getting-an-mot) by the third anniversary of its registration.
 ```
 
 The rendered output looks like this:
 
-> #### Check the MOT status of a vehicle
+> [!NOTE] Check the MOT status of a vehicle
 >
 > If your vehicle is new, you must [get an MOT test](https://www.gov.uk/getting-an-mot) by the third anniversary of its registration.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "markdown-it-attrs": "^4.3.1",
         "markdown-it-deflist": "^3.0.0",
         "markdown-it-footnote": "^4.0.0",
+        "markdown-it-github-alerts": "^1.0.0",
         "markdown-it-govuk": "^0.6.0",
         "markdown-it-image-figures": "^2.0.0",
         "markdown-it-ins": "^4.0.0",
@@ -7949,6 +7950,18 @@
       "resolved": "https://registry.npmjs.org/markdown-it-footnote/-/markdown-it-footnote-4.0.0.tgz",
       "integrity": "sha512-WYJ7urf+khJYl3DqofQpYfEYkZKbmXmwxQV8c8mO/hGIhgZ1wOe7R4HLFNwqx7TjILbnC98fuyeSsin19JdFcQ==",
       "license": "MIT"
+    },
+    "node_modules/markdown-it-github-alerts": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-github-alerts/-/markdown-it-github-alerts-1.0.0.tgz",
+      "integrity": "sha512-RU3cbB/ewujrDpYNdyabvp4CscZ5J/3D71NWbJW+JSA0nplfutIXDMCwtGWlMLwzgBDAYkFMvYGkigq8nWOVdA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "markdown-it": ">= 13.0.0"
+      }
     },
     "node_modules/markdown-it-govuk": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "markdown-it-attrs": "^4.3.1",
     "markdown-it-deflist": "^3.0.0",
     "markdown-it-footnote": "^4.0.0",
+    "markdown-it-github-alerts": "^1.0.0",
     "markdown-it-govuk": "^0.6.0",
     "markdown-it-image-figures": "^2.0.0",
     "markdown-it-ins": "^4.0.0",

--- a/src/components/_index.scss
+++ b/src/components/_index.scss
@@ -4,6 +4,7 @@
 @forward "document-list";
 @forward "footnotes-list";
 @forward "header";
+@forward "inset-text";
 @forward "link";
 @forward "metadata";
 @forward "prose-scope";

--- a/src/components/inset-text/_index.scss
+++ b/src/components/inset-text/_index.scss
@@ -1,0 +1,21 @@
+@use "govuk-frontend/dist/govuk" as *;
+
+.app-inset-text--tip {
+  background-color: govuk-tint(govuk-colour("blue"), 90%);
+  border-color: govuk-colour("blue");
+}
+
+.app-inset-text--important {
+  background-color: govuk-tint(govuk-colour("bright-purple"), 85%);
+  border-color: govuk-colour("bright-purple");
+}
+
+.app-inset-text--warning {
+  background-color: govuk-tint(govuk-colour("yellow"), 75%);
+  border-color: govuk-colour("brown");
+}
+
+.app-inset-text--caution {
+  background-color: govuk-tint(govuk-colour("red"), 75%);
+  border-color: govuk-colour("red");
+}

--- a/src/markdown-it.js
+++ b/src/markdown-it.js
@@ -5,6 +5,7 @@ import markdownItAnchor from 'markdown-it-anchor'
 import markdownItAttrs from 'markdown-it-attrs'
 import markdownItDeflist from 'markdown-it-deflist'
 import markdownItFootnote from 'markdown-it-footnote'
+import MarkdownItGitHubAlerts from 'markdown-it-github-alerts'
 import markdownItGovuk from 'markdown-it-govuk'
 import highlight from 'markdown-it-govuk/highlight'
 import markdownItImageFigures from 'markdown-it-image-figures'
@@ -14,6 +15,7 @@ import markdownItSub from 'markdown-it-sub'
 import markdownItSup from 'markdown-it-sup'
 import markdownItTableOfContents from 'markdown-it-table-of-contents'
 
+import { alertRules } from './markdown-it/alert.js'
 import { defListRules } from './markdown-it/deflist.js'
 import { footnotesRules } from './markdown-it/footnote.js'
 import { tableRules } from './markdown-it/table.js'
@@ -54,6 +56,8 @@ export function md(options = {}) {
     .use(defListRules)
     .use(markdownItFootnote)
     .use(footnotesRules)
+    .use(MarkdownItGitHubAlerts)
+    .use(alertRules)
     .use(markdownItIns)
     .use(markdownItImageFigures, {
       figcaption: true

--- a/src/markdown-it/alert.js
+++ b/src/markdown-it/alert.js
@@ -1,0 +1,23 @@
+/**
+ * Render a GitHub-style alert
+ *
+ * @param {Function} md - markdown-it instance
+ */
+export function alertRules(md) {
+  const { rules } = md.renderer
+
+  rules.alert_open = function (tokens, idx) {
+    const { title, type } = tokens[idx].meta
+
+    const visuallyHiddenTitle = type.charAt(0).toUpperCase() + type.slice(1)
+    const hasCustomTitle = title !== visuallyHiddenTitle
+
+    let html = `<div class="govuk-inset-text app-inset-text--${type}">`
+
+    html += hasCustomTitle
+      ? `<h3 class="govuk-heading-m"><span class="govuk-visually-hidden">${visuallyHiddenTitle}: </span>${title}</h3>`
+      : `<span class="govuk-visually-hidden">${visuallyHiddenTitle}: </span>`
+
+    return html
+  }
+}

--- a/test/markdown-it.js
+++ b/test/markdown-it.js
@@ -23,6 +23,24 @@ describe('markdown-it', () => {
     )
   })
 
+  it('Renders a note alert as inset text', () => {
+    const result = md().render('> [!NOTE]\n> Text')
+
+    assert.equal(
+      result,
+      `<div class="govuk-inset-text app-inset-text--note"><span class="govuk-visually-hidden">Note: </span><p class="govuk-body">Text</p>\n</div>\n`
+    )
+  })
+
+  it('Renders a note alert with title as inset text with heading', () => {
+    const result = md().render('> [!NOTE] Heading\n> Text')
+
+    assert.equal(
+      result,
+      `<div class="govuk-inset-text app-inset-text--note"><h3 class="govuk-heading-m"><span class="govuk-visually-hidden">Note: </span>Heading</h3><p class="govuk-body">Text</p>\n</div>\n`
+    )
+  })
+
   it('Renders a definition list', () => {
     const result = md().render('Term\n: Definition')
 


### PR DESCRIPTION
Based on the equivalent feature added to the [NHS.UK Eleventy Plugin](https://github.com/x-govuk/nhsuk-eleventy-plugin/pull/13)

This PR solves 2 issues:

1. There is no way to render inset text. Although it may be tempting to use the blockquote syntax, this is rarely the correct markup for such content.

2. GitHub alerts in Markdown content will be rendered as blockquotes (again, using the incorrect markup) and show the alert type as text:

    <img width="720" height="115" alt="Screenshot of alert rendered as a block quote." src="https://github.com/user-attachments/assets/8dda9a0a-9a4c-4cb8-802b-dfa3aa4c1501" />

This PR supports [the 5 different alert types](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts), and renders them using the inset text component from the GOV.UK Design System. While a note alert will use the standard design, the 4 other alert types use a coloured background and border:

<img width="985" height="555" alt="Screenshot of different alert types." src="https://github.com/user-attachments/assets/bdaa8159-c37a-4476-9e81-b3d8cd70ec13" />
 
This is because the markup for warning text isn’t compatible with the GitHub alert markdown-it plugin, and isn’t designed to accept anything more than one line of text.