### PR TITLE
Add support for Govspeak markdown extensions

### DIFF
--- a/example/markdown.md
+++ b/example/markdown.md
@@ -556,3 +556,32 @@ Here’s a simple footnote,[^1] and here’s a longer one.[^longer]
 | Copyright            | `(C)` `(c)`           | (C)                 |
 | Registered trademark | `(R)` `(r)`           | (R)                 |
 | Trademark            | `(TM)` `(tm)`         | (TM)                |
+
+## Govspeak
+
+==Todo: Integrate examples into above==
+
+### Address
+
+$A
+HM Revenue and Customs
+Bradford
+BD98 1YY
+$A
+
+### Example callout
+
+$E
+**Example** This is an indented example block.
+It may span multiple lines, [contain links](#).
+
+It may even span multiple paragraphs.
+$E
+
+### Information callout
+
+%The water in the mouth of a blue whale weighs more than its body.%
+
+### Warning callout
+
+^If you drilled a tunnel straight through the Earth and jumped in, it would take you exactly 42 minutes and 12 seconds to get to the other side.^

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "markdown-it-deflist": "^3.0.0",
         "markdown-it-footnote": "^4.0.0",
         "markdown-it-github-alerts": "^1.0.0",
-        "markdown-it-govuk": "^0.7.0",
+        "markdown-it-govuk": "github:x-govuk/markdown-it-govuk#govspeak",
         "markdown-it-image-figures": "^2.0.0",
         "markdown-it-ins": "^4.0.0",
         "markdown-it-mark": "^4.0.0",
@@ -7918,8 +7918,7 @@
     },
     "node_modules/markdown-it-govuk": {
       "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/markdown-it-govuk/-/markdown-it-govuk-0.7.0.tgz",
-      "integrity": "sha512-dPzReMTc1b/jIvnNTVxeWbFPQ7JXI7jg0hO2CM22C/tzFZxYqYKs01Jo5L5lTvSMaCxBO65HWslaoyMDkJLQ9w==",
+      "resolved": "git+ssh://git@github.com/x-govuk/markdown-it-govuk.git#4a94918eab87ab1890d245248f1ec8afb2f45fd6",
       "license": "MIT",
       "dependencies": {
         "highlight.js": "^11.5.0"

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "markdown-it-deflist": "^3.0.0",
     "markdown-it-footnote": "^4.0.0",
     "markdown-it-github-alerts": "^1.0.0",
-    "markdown-it-govuk": "^0.7.0",
+    "markdown-it-govuk": "github:x-govuk/markdown-it-govuk#govspeak",
     "markdown-it-image-figures": "^2.0.0",
     "markdown-it-ins": "^4.0.0",
     "markdown-it-mark": "^4.0.0",

--- a/src/data/options.js
+++ b/src/data/options.js
@@ -22,7 +22,8 @@ const defaults = {
   },
   markdown: {
     headingPermalinks: false,
-    headingsStartWith: 'xl'
+    headingsStartWith: 'xl',
+    govspeak: true
   },
   opengraphImageUrl: '/assets/rebrand/images/govuk-opengraph-image.png',
   stylesheets: [],

--- a/src/markdown-it.js
+++ b/src/markdown-it.js
@@ -41,7 +41,8 @@ export function md(markdownOptions = {}) {
   const md = new MarkdownIt(opts)
     .use(markdownItGovuk, {
       calvert: true,
-      headingsStartWith: markdownOptions.headingsStartWith
+      headingsStartWith: markdownOptions.headingsStartWith,
+      govspeak: markdownOptions.govspeak
     })
     .use(markdownItAbbr)
     .use(markdownItAnchor, {


### PR DESCRIPTION
To do

- [ ] Update Markdown examples
- [ ] Update `markdown` options in documentation