### PR TITLE
Add optional phase banner support

### DIFF
--- a/docs/get-started/options.md
+++ b/docs/get-started/options.md
@@ -55,7 +55,44 @@ Alongside [options available for the header component](https://design-system.ser
 | logotype      | object | Logo that appears in the header. If no value is provided, the GOV.UK logo is shown.                                                                                    |
 | logotype.text | string | Text to show instead of the GOV.UK logo. This text will appear bold. If `html` is set, this is not required. If `html` is provided, the `text` option will be ignored. |
 | logotype.html | string | If `text` is set, this is not required. If `html` is provided, the `text` option will be ignored.                                                                      |
+| phaseBanner   | object | See [options for phase banner](#options-for-phasebanner-object)                                                                                                        |
 | search        | object | See [options for search](#options-for-search-object)                                                                                                                   |
+
+## Options for `phaseBanner` object
+
+Show a phase banner to indicate your service is in alpha or beta. The banner appears below the header and service navigation.
+
+Alongside [options available for the phase banner component](https://design-system.service.gov.uk/components/phase-banner/), the following options can be set:
+
+| Name       | Type   | Description                                                                   |
+| ---------- | ------ | ----------------------------------------------------------------------------- |
+| tag        | object | Required. Phase tag config (e.g., `{ text: "Alpha" }` or `{ text: "Beta" }`). |
+| tag.text   | string | Text for the phase tag. If `html` is set, this is not required.               |
+| tag.html   | string | HTML for the phase tag. If provided, `text` is ignored.                       |
+| text       | string | Text to display in the banner message.                                        |
+| html       | string | HTML for banner message. If provided, `text` is ignored.                      |
+| classes    | string | Additional CSS classes for the phase banner container.                        |
+| attributes | object | HTML attributes (e.g., data attributes) for the phase banner container.       |
+
+### Example
+
+```js
+import { govukEleventyPlugin } from '@x-govuk/govuk-eleventy-plugin'
+
+export default function(eleventyConfig) {
+  eleventyConfig.addPlugin(govukEleventyPlugin, {
+    header: {
+      productName: 'Apply for a juggling licence',
+      phaseBanner: {
+        tag: {
+          text: 'Alpha'
+        },
+        html: 'This is a new service. Help us improve it and <a class="govuk-link" href="/feedback">give your feedback</a>.'
+      }
+    }
+  })
+}
+```
 
 ## Options for `serviceNavigation` object
 
@@ -86,7 +123,7 @@ Alongside [options available for the footer component](https://design-system.ser
 | contentLicence      | object  | Licence description. If no value is provided, the OGL logo is shown alongside the words `All content is available under the Open Government Licence v3.0, except where otherwise stated`. Set to `false` to remove completely. |
 | contentLicence.text | string  | If `html` is set, this is not required. If `html` is provided, the `text` option will be ignored.                                                                                                                              |
 | contentLicence.html | string  | If `text` is set, this is not required. If `html` is provided, the `text` option will be ignored.                                                                                                                              |
-| copyright           | object  | Copyright statement. If no value is provided, `© Crown copyright` is displayed below an image of the Royal Coat of Arms. Set to `false` to remove completely.                                                                 |
+| copyright           | object  | Copyright statement. If no value is provided, `© Crown copyright` is displayed below an image of the Royal Coat of Arms. Set to `false` to remove completely.                                                                  |
 | copyright.text      | string  | If `html` is set, this is not required. If `html` is provided, the `text` option will be ignored.                                                                                                                              |
 | copyright.html      | string  | If `text` is set, this is not required. If `html` is provided, the `text` option will be ignored.                                                                                                                              |
 | logo                | boolean | Show logo in footer (default is `true`)                                                                                                                                                                                        |

--- a/src/layouts/base.njk
+++ b/src/layouts/base.njk
@@ -20,6 +20,7 @@
 {# Components #}
 {% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
 {% from "govuk/components/pagination/macro.njk" import govukPagination %}
+{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
 
 {% from "x-govuk/components/masthead/macro.njk" import xGovukMasthead %}
 {% from "x-govuk/components/related-navigation/macro.njk" import xGovukRelatedNavigation %}
@@ -69,6 +70,9 @@
 {% block header %}
   {{ appHeader(options.header) }}
   {{ appServiceNavigation(options.serviceNavigation) if options.serviceNavigation }}
+  {% block phaseBanner %}
+    {{ govukPhaseBanner(options.header.phaseBanner) if options.header.phaseBanner }}
+  {% endblock %}
 {% endblock %}
 
 {% block footer %}


### PR DESCRIPTION
## Summary

Add support for the GOV.UK Phase Banner component, configurable via `header.phaseBanner` option. The phase banner indicates a service is in alpha or beta development phase and appears below the header and service navigation (per GOV.UK Design System guidelines).

## Changes

- Add `govukPhaseBanner` macro import to `src/layouts/base.njk`
- Add conditional rendering of phase banner in header block with overridable `{% block phaseBanner %}`
- Document `phaseBanner` option in `docs/get-started/options.md` with full parameter reference and example

## Configuration example

```js
eleventyConfig.addPlugin(govukEleventyPlugin, {
  header: {
    productName: 'Apply for a juggling licence',
    phaseBanner: {
      tag: {
        text: 'Alpha'
      },
      html: 'This is a new service. Help us improve it and <a class="govuk-link" href="/feedback">give your feedback</a>.'
    }
  }
})
```

## Test plan

- [x] Build passes
- [x] Lint passes
- [x] All existing tests pass (35/35)
- [x] No phase banner renders when config not provided
- [x] Phase banner renders correctly when configured