### PR TITLE
Fix phase-banner width by defaulting to govuk-width-container class

### DIFF
--- a/docs/get-started/options.md
+++ b/docs/get-started/options.md
@@ -64,15 +64,15 @@ Show a phase banner to indicate your service is in alpha or beta. The banner app
 
 Alongside [options available for the phase banner component](https://design-system.service.gov.uk/components/phase-banner/), the following options can be set:
 
-| Name       | Type   | Description                                                                   |
-| ---------- | ------ | ----------------------------------------------------------------------------- |
-| tag        | object | Required. Phase tag config (e.g., `{ text: "Alpha" }` or `{ text: "Beta" }`). |
-| tag.text   | string | Text for the phase tag. If `html` is set, this is not required.               |
-| tag.html   | string | HTML for the phase tag. If provided, `text` is ignored.                       |
-| text       | string | Text to display in the banner message.                                        |
-| html       | string | HTML for banner message. If provided, `text` is ignored.                      |
-| classes    | string | Additional CSS classes for the phase banner container.                        |
-| attributes | object | HTML attributes (e.g., data attributes) for the phase banner container.       |
+| Name       | Type   | Description                                                                                 |
+| ---------- | ------ | ------------------------------------------------------------------------------------------- |
+| tag        | object | Required. Phase tag config (e.g., `{ text: "Alpha" }` or `{ text: "Beta" }`).               |
+| tag.text   | string | Text for the phase tag. If `html` is set, this is not required.                             |
+| tag.html   | string | HTML for the phase tag. If provided, `text` is ignored.                                     |
+| text       | string | Text to display in the banner message.                                                      |
+| html       | string | HTML for banner message. If provided, `text` is ignored.                                    |
+| classes    | string | Additional CSS classes for the phase banner container (default is `govuk-width-container`). |
+| attributes | object | HTML attributes (e.g., data attributes) for the phase banner container.                     |
 
 ### Example
 
@@ -84,7 +84,6 @@ export default function(eleventyConfig) {
     header: {
       productName: 'Apply for a juggling licence',
       phaseBanner: {
-        classes: 'govuk-width-container',
         tag: {
           text: 'Alpha'
         },

--- a/src/data/options.js
+++ b/src/data/options.js
@@ -61,5 +61,10 @@ export function defaultPluginOptions(options, pathPrefix) {
     }
   }
 
+  // Default phaseBanner classes to govuk-width-container for proper width
+  if (options.header?.phaseBanner && !options.header.phaseBanner.classes) {
+    options.header.phaseBanner.classes = 'govuk-width-container'
+  }
+
   return deepmerge(defaults, options)
 }


### PR DESCRIPTION
## Summary

Apologies - I missed something in #417. During my testing I didn't notice how broken the phase banner looks without the `govuk-width-container` class specified. Without it, the banner spans the full viewport width rather than aligning with the rest of the page content.

I also omitted to make clear in the documentation that this class was required for proper display.

This PR fixes both issues:
- **Code fix**: The `classes` option now defaults to `govuk-width-container` when not specified, ensuring correct width out of the box
- **Doc update**: Updated the documentation to reflect this default behaviour and removed it from the example (since it's no longer needed to be explicitly set)

## Changes

- `src/data/options.js`: Add default `classes: 'govuk-width-container'` for phaseBanner when not specified
- `docs/get-started/options.md`: Document the default and simplify the example

Users can still override with their own `classes` value if needed.